### PR TITLE
[UI]: Refactor view select modal to command palette style

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,4 +15,4 @@
 12. A simple progress bar integrated into the modal. It will replace the input field and show a percentage. If the user presses <esc> to leave the view, small text in the footer area should reflext that <model> is being pulled.
 
 # PRIORITY BUGS
-- The spinner for displaying when a chat is being processed dissapears instantly. Look at the logs .ryan/debug.spinner-disapear.log
+-  Look at the logs .ryan/debug.spinner-disapear.log. It appears that an error occured but there was no alert or text notifying one occurred appeared. This error text should be displayed as a red chat message.

--- a/TODO.md
+++ b/TODO.md
@@ -4,11 +4,15 @@
 ~~4. Pressing <enter> on a model changes the selected model and actually writes this change to the settings yaml~~
 ~~4. Pressing <esc> on any view other than chat should re-focus the chat view~~
 ~~5. The view menu should also have vim sytle j/k movement.~~
-~~~~6. We need to make sure to handle the case where ollama is not avail and show a modal that says, "Cannot connect to ollama on <configured url>"~~~~
+~~6. We need to make sure to handle the case where ollama is not avail and show a modal that says, "Cannot connect to ollama on <configured url>"~~
 ~~7. When we do have a connection to ollama, we need to make sure there is a model to use. If there is only one avail in ollama we need to make sure that the text showing the default model is red-strikethrough to show unavailability. This should be the case whenever any model that is set is not avail in ollama.~~
 7. When we do have a connection to ollama, we need to make sure there is a model to use. If there is only one avail in ollama we need to make sure that the text showing the default model is red-strikethrough to show unavailability. This should be the case whenever any model that is set is not avail in ollama.
-8. Refactor the "view select modal" to be more of a command pallette - a little wider, ho header, a straight simple list of views and actions.
+~~8. Refactor the "view select modal" to be more of a command pallette - a little wider, ho header, a straight simple list of views and actions.~~
 9. On the model management view, add a keyboard command, "n" to bring up a modal text input field for entering in a model name to pull. Pressing <enter> will begin pulling this model.
 10. On the modal management page, pressing ctrl-d should delete a model with a simple confirm prompt.
+10. When the footer status has an update: "Model changed" or something, it needs to remove the message after 2 seconds back to the default state.
 11. From the model management view, help text at the bottom should show that pressing "n" will pull a new model.
 12. A simple progress bar integrated into the modal. It will replace the input field and show a percentage. If the user presses <esc> to leave the view, small text in the footer area should reflext that <model> is being pulled.
+
+# PRIORITY BUGS
+- The spinner for displaying when a chat is being processed dissapears instantly. Look at the logs .ryan/debug.spinner-disapear.log

--- a/pkg/tui/menu.go
+++ b/pkg/tui/menu.go
@@ -95,21 +95,13 @@ func (mc MenuComponent) Render(screen tcell.Screen, area Rect) {
 		return
 	}
 
-	borderStyle := tcell.StyleDefault.Foreground(tcell.ColorWhite)
+	borderStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
 	selectedStyle := tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorOrange)
 	normalStyle := tcell.StyleDefault.Foreground(tcell.ColorWhite)
-	titleStyle := tcell.StyleDefault.Foreground(tcell.ColorYellow).Bold(true)
 
 	drawBorder(screen, area, borderStyle)
 
-	titleText := "Select View"
-	titleX := area.X + (area.Width-len(titleText))/2
-	if titleX < area.X+1 {
-		titleX = area.X + 1
-	}
-	renderTextWithLimit(screen, titleX, area.Y+1, len(titleText), titleText, titleStyle)
-
-	startY := area.Y + 3
+	startY := area.Y + 1
 	for i, option := range mc.options {
 		if startY+i >= area.Y+area.Height-1 {
 			break
@@ -121,34 +113,25 @@ func (mc MenuComponent) Render(screen tcell.Screen, area Rect) {
 		}
 
 		optionText := option.Description
-		if len(optionText) > area.Width-6 {
-			optionText = optionText[:area.Width-9] + "..."
+		maxTextWidth := area.Width - 4
+		if maxTextWidth > 3 && len(optionText) > maxTextWidth {
+			cutoffWidth := maxTextWidth - 3
+			if cutoffWidth > 0 && cutoffWidth < len(optionText) {
+				optionText = optionText[:cutoffWidth] + "..."
+			}
 		}
-
-		numberText := string(rune('1' + i))
-		fullText := numberText + ". " + optionText
 
 		// Fill the entire row with the background color for selected item
 		for x := area.X + 1; x < area.X+area.Width-1; x++ {
 			char := ' '
 			textIndex := x - (area.X + 2)
-			if textIndex >= 0 && textIndex < len([]rune(fullText)) {
-				fullTextRunes := []rune(fullText)
-				char = fullTextRunes[textIndex]
+			if textIndex >= 0 && textIndex < len([]rune(optionText)) {
+				optionTextRunes := []rune(optionText)
+				char = optionTextRunes[textIndex]
 			}
 			screen.SetContent(x, startY+i, char, nil, style)
 		}
 	}
-
-	instructionText := "Use ↑↓ or 1-9, Enter to select, Esc to cancel"
-	if len(instructionText) > area.Width-4 {
-		instructionText = "↑↓ or 1-9, Enter, Esc"
-	}
-	instrX := area.X + (area.Width-len(instructionText))/2
-	if instrX < area.X+1 {
-		instrX = area.X + 1
-	}
-	renderTextWithLimit(screen, instrX, area.Y+area.Height-2, len(instructionText), instructionText, normalStyle)
 }
 
 func drawBorder(screen tcell.Screen, area Rect, style tcell.Style) {

--- a/pkg/tui/views.go
+++ b/pkg/tui/views.go
@@ -134,14 +134,6 @@ func (vm *ViewManager) HandleMenuKeyEvent(ev *tcell.EventKey) bool {
 			case 'k', 'K':
 				vm.menu = vm.menu.SelectPrevious()
 				return true
-			default:
-				if ev.Rune() >= '1' && ev.Rune() <= '9' {
-					index := int(ev.Rune() - '1')
-					if viewName := vm.menu.GetOptionByIndex(index); viewName != "" {
-						vm.SetCurrentView(viewName)
-						return true
-					}
-				}
 			}
 		}
 	}
@@ -173,7 +165,7 @@ func (vm *ViewManager) renderMenu(screen tcell.Screen, area Rect) {
 		return
 	}
 
-	// Calculate optimal menu width based on content
+	// Calculate optimal menu width based on content - wider command palette style
 	maxDescLen := 0
 	for _, view := range vm.views {
 		descLen := len(view.Description())
@@ -182,21 +174,21 @@ func (vm *ViewManager) renderMenu(screen tcell.Screen, area Rect) {
 		}
 	}
 
-	// Menu width: longest description + number + spacing + padding
-	menuWidth := maxDescLen + 10 // "1. " + description + padding
-	if menuWidth < 50 {
-		menuWidth = 50 // minimum width
+	// Command palette style: wider menu with more padding
+	menuWidth := maxDescLen + 8 // description + padding
+	if menuWidth < 60 {
+		menuWidth = 60 // minimum width for command palette
 	}
-	if menuWidth > area.Width-10 {
-		menuWidth = area.Width - 10 // leave margin
+	if menuWidth > area.Width-6 {
+		menuWidth = area.Width - 6 // minimal margin
 	}
 
 	// Ensure minimum menu width
-	if menuWidth < 20 {
-		menuWidth = 20
+	if menuWidth < 30 {
+		menuWidth = 30
 	}
 
-	menuHeight := len(vm.views) + 6 // options + title + instructions + borders
+	menuHeight := len(vm.views) + 2 // options + borders only (no header/footer)
 
 	// Ensure minimum menu height
 	if menuHeight < 6 {


### PR DESCRIPTION
## Summary
- Refactored the view select modal to be more like a command palette
- Removed header title for cleaner appearance
- Increased minimum width from 50px to 60px
- Removed numbered shortcuts (1-9) for simpler interaction
- Fixed slice bounds bug in text truncation for small terminal sizes

## Test plan
- [x] All existing TUI tests pass
- [x] Menu renders correctly in various terminal sizes
- [x] Navigation with j/k and arrow keys works
- [x] Enter key selects views properly
- [x] Escape key closes menu

🤖 Generated with [Claude Code](https://claude.ai/code)