### PR TITLE
[BUG FIX]: Remove duplicate error messages, only show in chat

### DIFF
--- a/pkg/tui/chat_view.go
+++ b/pkg/tui/chat_view.go
@@ -151,7 +151,8 @@ func (cv *ChatView) HandleMessageResponse(response MessageResponseEvent) {
 
 func (cv *ChatView) HandleMessageError(error MessageErrorEvent) {
 	cv.status = cv.status.WithStatus("Ready") // Keep status simple
-	cv.alert = cv.alert.WithError("Error: " + error.Error.Error())
+	// Don't set alert error - only show error in chat messages
+	cv.alert = cv.alert.Clear()
 	
 	// Update messages to show the error message that was added to conversation
 	cv.updateMessages()
@@ -165,10 +166,8 @@ func (cv *ChatView) SyncWithAppState(sending bool) {
 	if sending {
 		cv.alert = cv.alert.WithSpinner(true, "")
 	} else {
-		// Only clear alert if there's no error message
-		if cv.alert.ErrorMessage == "" {
-			cv.alert = cv.alert.Clear()
-		}
+		// Always clear alert since errors only show in chat messages now
+		cv.alert = cv.alert.Clear()
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixed the bug where error messages were being displayed in two locations - both in the alert area and as chat messages. Now errors only appear as red chat messages in the conversation history for a cleaner user experience.

## Changes Made
- **Removed alert error display**: No longer set error in alert area in `HandleMessageError()`
- **Simplified state management**: `SyncWithAppState()` now always clears alerts when not sending
- **Single error location**: Errors only appear as red messages in chat history

## Before vs After
- **Before**: Error appeared both in alert area at bottom AND as red chat message (duplicate)
- **After**: Error only appears as red chat message in conversation (single location)

## Test Plan
- [x] Unit tests pass
- [x] Error messages still appear in red in chat history
- [x] No duplicate error messages in UI
- [x] Alert area is properly cleared after errors

🤖 Generated with [Claude Code](https://claude.ai/code)