### PR TITLE
[Logging]: Consolidate to single log file with level-based filtering

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -11,16 +10,14 @@ import (
 
 type Logger struct {
 	*slog.Logger
-	errorLogger *slog.Logger
 }
 
 var defaultLogger *Logger
-var errorFile *os.File
-var stdoutFile *os.File
+var logFile *os.File
 var historyFile *os.File
 
 func init() {
-	defaultLogger = &Logger{slog.Default(), slog.Default()}
+	defaultLogger = &Logger{slog.Default()}
 }
 
 func InitLogger() error {
@@ -28,27 +25,18 @@ func InitLogger() error {
 	return InitLoggerWithConfig(".ryan/logs/debug.log", false, "info")
 }
 
-func InitLoggerWithConfig(logFile string, preserve bool, level string) error {
-	if logFile == "" {
-		logFile = ".ryan/logs/debug.log"
+func InitLoggerWithConfig(logPath string, preserve bool, level string) error {
+	if logPath == "" {
+		logPath = ".ryan/logs/debug.log"
 	}
 
 	// Ensure directory exists
-	dir := filepath.Dir(logFile)
+	dir := filepath.Dir(logPath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create log directory: %w", err)
 	}
 
-	// Open stdout log file (always truncated)
-	stdoutPath := filepath.Join(dir, "stdout.log")
-	var err error
-	stdoutFile, err = os.OpenFile(stdoutPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to open stdout log file: %w", err)
-	}
-
-	// Open error log file
-	errorPath := filepath.Join(dir, "error.log")
+	// Open single log file (respects preserve setting)
 	flag := os.O_CREATE | os.O_WRONLY
 	if preserve {
 		flag |= os.O_APPEND
@@ -56,10 +44,10 @@ func InitLoggerWithConfig(logFile string, preserve bool, level string) error {
 		flag |= os.O_TRUNC
 	}
 
-	errorFile, err = os.OpenFile(errorPath, flag, 0644)
+	var err error
+	logFile, err = os.OpenFile(logPath, flag, 0644)
 	if err != nil {
-		stdoutFile.Close()
-		return fmt.Errorf("failed to open error log file: %w", err)
+		return fmt.Errorf("failed to open log file: %w", err)
 	}
 
 	// Parse log level
@@ -91,28 +79,15 @@ func InitLoggerWithConfig(logFile string, preserve bool, level string) error {
 		},
 	}
 
-	// Error logger options (only errors)
-	errorOpts := &slog.HandlerOptions{
-		Level:       slog.LevelError,
-		ReplaceAttr: opts.ReplaceAttr,
-	}
+	// Create handler for single log file
+	handler := slog.NewTextHandler(logFile, opts)
+	logger := slog.New(handler)
 
-	// Create multi-writer for stdout log
-	multiWriter := io.MultiWriter(stdoutFile)
-
-	// Create handlers
-	stdoutHandler := slog.NewTextHandler(multiWriter, opts)
-	errorHandler := slog.NewTextHandler(errorFile, errorOpts)
-
-	logger := slog.New(stdoutHandler)
-	errLogger := slog.New(errorHandler)
-
-	defaultLogger = &Logger{logger, errLogger}
+	defaultLogger = &Logger{logger}
 
 	// Log initialization
 	defaultLogger.Info("Logger initialized",
-		"stdout", stdoutPath,
-		"error", errorPath,
+		"file", logPath,
 		"preserve", preserve,
 		"level", level,
 	)
@@ -127,21 +102,13 @@ func Get() *Logger {
 func (l *Logger) WithComponent(component string) *Logger {
 	return &Logger{
 		l.Logger.With("component", component),
-		l.errorLogger.With("component", component),
 	}
 }
 
 func (l *Logger) WithContext(key string, value any) *Logger {
 	return &Logger{
 		l.Logger.With(key, value),
-		l.errorLogger.With(key, value),
 	}
-}
-
-// Override Error method to write to both loggers
-func (l *Logger) Error(msg string, args ...any) {
-	l.Logger.Error(msg, args...)
-	l.errorLogger.Error(msg, args...)
 }
 
 // Convenience functions
@@ -158,10 +125,7 @@ func Warn(msg string, args ...any) {
 }
 
 func Error(msg string, args ...any) {
-	if defaultLogger.errorLogger != nil {
-		defaultLogger.errorLogger.Error(msg, args...)
-	}
-	defaultLogger.Logger.Error(msg, args...)
+	defaultLogger.Error(msg, args...)
 }
 
 func WithComponent(component string) *Logger {
@@ -255,15 +219,9 @@ func LogChatEvent(event, details string) error {
 func Close() error {
 	var errs []error
 
-	if stdoutFile != nil {
-		if err := stdoutFile.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to close stdout log: %w", err))
-		}
-	}
-
-	if errorFile != nil {
-		if err := errorFile.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to close error log: %w", err))
+	if logFile != nil {
+		if err := logFile.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close log file: %w", err))
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Refactored logging system from 3 separate files to 1 unified log file
- Replaced file-based separation (debug.log, stdout.log, error.log) with level-based filtering  
- Simplified Logger struct and removed duplicate error handling logic
- Maintained backward compatibility with existing configuration

## Changes Made
- **Single log file**: All messages now go to one configured file (default: `.ryan/logs/debug.log`)
- **Level-based filtering**: The `logging.level` setting controls verbosity:
  - `debug`: Shows all messages (debug, info, warn, error)
  - `info`: Shows info, warn, error messages
  - `warn`: Shows warn, error messages  
  - `error`: Shows only error messages
- **Simplified architecture**: Single `Logger` struct wrapping `slog.Logger`
- **Preserved functionality**: `logging.preserve` flag still works for truncate vs append behavior
- **Chat history unchanged**: Remains separate in `debug.history` file

## Benefits
- **Cleaner file management**: One log file instead of three
- **True level-based filtering**: Messages filtered at handler level, not by destination
- **Reduced complexity**: Removed duplicate error logger handling
- **Better user experience**: Single file to monitor with adjustable verbosity

## Test plan
- [x] All existing tests pass
- [x] Build succeeds without errors
- [x] Logging configuration remains backward compatible
- [x] Preserve flag functionality verified
- [x] Level filtering behavior confirmed

🤖 Generated with [Claude Code](https://claude.ai/code)