### PR TITLE
[Config]: Remove LangChain toggle options and add self.yaml support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Self Configuration Support**: Added support for self.yaml configuration file
+  - Separate viper instance for self.yaml configuration
+  - `SelfConfig` and `SelfTrait` structs for AI persona configuration
+  - `GetSelf()` function to access self configuration
+  - `self_config_path` setting with default `./.ryan/self.yaml`
+  - Example self.yaml configurations in examples directory
+
+### Added
 - **Enhanced Status Row**: Improved status information display with format `<SPINNER> <FEEDBACK_TEXT> (<DURATION> | <NUM_TOKENS> | <bold>esc</bold> to interject)`
   - Real-time duration tracking during operations
   - Integrated token count display in status row
@@ -25,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Status Row Layout**: Improved status row positioning and content layout
 
 ### Changed
+- **BREAKING: LangChain-Only Mode**: LangChain is now the only mode of operation
+  - Removed ability to disable LangChain
+  - Removed all conditional logic for alternate modes
+  - Simplified configuration and codebase
+- **BREAKING: Configuration Key Changes**:
+  - Changed `logging.file` to `logging.log_file` in configuration
+  - Fixed LangChain tools configuration keys:
+    - `autonomous_execution` → `autonomous_reasoning`
+    - `use_agent_framework` → `use_react_pattern`
 - **Code Quality**: Cleaned up debug logging statements across the codebase
   - Removed extensive debug logging blocks from `pkg/langchain/client.go`
   - Cleaned up debug statements in TUI rendering components
@@ -71,6 +88,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Model list now displays tool compatibility icons
   - Updated help text to explain tool capability indicators
   - Enhanced model selection feedback with compatibility warnings
+
+### Removed
+- **Configuration Options**:
+  - Removed `UseLangchain` field from `SearchConfig`
+  - Removed `ollama.use_langchain` configuration option
+  - Removed unused `langchain.enabled` configuration
+  - Removed unused `langchain.streaming.use_langchain` configuration
+  - Removed unused `langchain.streaming.provider_optimization` configuration
+  - Removed unused `langchain.prompts.use_templates` configuration
+  - Removed all references to conditional LangChain usage
 
 ### Security
 - **Tool Safety Features**:

--- a/docs/LANGCHAIN_INTEGRATION_STRATEGY.md
+++ b/docs/LANGCHAIN_INTEGRATION_STRATEGY.md
@@ -9,7 +9,7 @@ Ryan currently has **partial LangChain integration** but is not leveraging the f
 - ✅ Basic LangChain memory wrapper (`LangChainMemory`)
 - ✅ LangChain chat controller that extends base controller
 - ✅ LangChain streaming client using LLM interface
-- ✅ Configuration flag `use_langchain: true`
+- ✅ LangChain is the only mode of operation (no alternate paths)
 - ✅ Conversion utilities between our types and LangChain types
 
 ### What We're Missing 🚧
@@ -241,7 +241,6 @@ langchain:
   enabled: true
   
   streaming:
-    use_langchain: true          # Use LangChain streaming vs custom
     provider_optimization: true  # Provider-specific optimizations
   
   tools:

--- a/examples/self.example.yaml
+++ b/examples/self.example.yaml
@@ -1,0 +1,34 @@
+# Example self.yaml configuration file
+# This file demonstrates how to configure AI traits for self-reflection
+
+role: self
+traits:
+- name: "explorer"
+  system_prompt: |
+    You are the inner explorer. You analyze your current environment and discover the tools and files that are available to you.
+    Focus on understanding the codebase structure, available commands, and development patterns.
+
+- name: "planner"
+  system_prompt: |
+    You are given broad goals and ideas. You break them down into smaller, more manageable tasks with clear and comprehensive steps.
+    Create actionable task lists with priorities and dependencies.
+
+- name: "task-manager"
+  system_prompt: |
+    You are a task manager. Your primary job is to delegate tasks and track their progress.
+    Monitor completion status and coordinate between different components.
+
+- name: "evaluator"
+  system_prompt: |
+    You are the inner evaluator. You analyze the results of the task manager and determine if the task was completed successfully.
+    Verify outcomes against requirements and ensure quality standards are met.
+
+- name: "skeptic"
+  system_prompt: |
+    You are a skeptic. You are always skeptical when told something has been completed. You must always have verification with proof.
+    Question assumptions and demand evidence for claims.
+
+- name: "paranoid"
+  system_prompt: |
+    You are paranoid that things are going to break. You always are ready with a plan B.
+    Anticipate failure scenarios and prepare contingency plans.

--- a/examples/self.reference.yaml
+++ b/examples/self.reference.yaml
@@ -1,0 +1,20 @@
+role: self
+traits:
+- name: "explorer"
+  system_prompt: |
+    You are the inner explorer. You analyze your current environment and discover the tools and files that are available to you.
+- name: "planner"
+  system_prompt: |
+    You are given broad goals and ideas. You break them down into smaller, more manageable tasks with clear and comprehensive steps.
+- name: "task-manager"
+  system_prompt: |
+    You are a task manager. Your primary job is to delegate tasks and track their progress.
+- name: "evaluator"
+  system_prompt: |
+    You are the inner evaluator. You analyze the results of the task manager and determine if the task was completed successfully.
+- name: "skeptic"
+  system_prompt: |
+    You are a skeptic. You are always skeptical when told something has been completed. You must always have verification with proof.
+- name: "paranoid"
+  system_prompt: |
+    You are paranoid that things are going to break. You always are ready with a plan B.

--- a/examples/settings.reference.yaml
+++ b/examples/settings.reference.yaml
@@ -41,7 +41,6 @@ tools:
   search:
     enabled: true
     timeout: 10s
-    use_langchain: false
 
 # LangChain
 langchain:

--- a/pkg/config/testdata/settings-with-missing-self.yaml
+++ b/pkg/config/testdata/settings-with-missing-self.yaml
@@ -1,0 +1,3 @@
+ollama:
+  url: http://test-ollama:11434
+self_config_path: ./testdata/missing-self.yaml

--- a/pkg/config/testdata/settings-with-self.yaml
+++ b/pkg/config/testdata/settings-with-self.yaml
@@ -1,0 +1,4 @@
+ollama:
+  url: http://test-ollama:11434
+  model: test-model
+self_config_path: ./testdata/test-self.yaml

--- a/pkg/config/testdata/test-self.yaml
+++ b/pkg/config/testdata/test-self.yaml
@@ -1,0 +1,8 @@
+role: self
+traits:
+- name: "explorer"
+  system_prompt: |
+    You are the inner explorer. You analyze your current environment and discover the tools and files that are available to you.
+- name: "planner"  
+  system_prompt: |
+    You are given broad goals and ideas. You break them down into smaller, more manageable tasks with clear and comprehensive steps.

--- a/pkg/config/testdata/test-settings.yaml
+++ b/pkg/config/testdata/test-settings.yaml
@@ -1,0 +1,13 @@
+ollama:
+  url: http://test-ollama:11434
+  model: test-model
+  timeout: "2m"
+  poll_interval: 5
+show_thinking: false
+logging:
+  log_file: /tmp/test.log
+  preserve: true
+tools:
+  bash:
+    timeout: "30s"
+    allowed_paths: ["/test", "/tmp"]


### PR DESCRIPTION
This commit makes LangChain the only mode of operation and adds support for a separate self.yaml configuration file for AI personas.

Breaking Changes:
- LangChain is now always enabled (removed ability to disable)
- Changed logging.file to logging.log_file in configuration
- Fixed LangChain tools configuration keys:
  - autonomous_execution → autonomous_reasoning
  - use_agent_framework → use_react_pattern

Added:
- Support for self.yaml configuration with separate viper instance
- SelfConfig and SelfTrait structs for AI persona configuration
- GetSelf() function to access self configuration
- self_config_path setting with default ./.ryan/self.yaml
- Example self.yaml configurations

Removed:
- UseLangchain field from SearchConfig
- ollama.use_langchain configuration option
- Unused langchain configuration options (enabled, streaming settings, etc.)
- All conditional logic for enabling/disabling LangChain

🤖 Generated with [Claude Code](https://claude.ai/code)