### PR TITLE
[Orchestrator]: Make orchestrator default mode with simplified agent feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Added
+- **Orchestrator as Default Mode** - Made orchestrator the default execution mode, removing the need for `--orchestrate` flag
+  - Removed single-agent mode entirely - all queries now go through the orchestrator
+  - Simplified command-line interface by removing `--simple` and `--orchestrate` flags
+  - Added minimal visual feedback showing which agent is currently processing with `[agent_name]` format
+  - Enhanced streaming to show agent responses in real-time
+  - Fixed TUI scrolling with proper viewport key handling and mouse wheel support
+  - Updated viewport API usage to non-deprecated methods (HalfPageUp/HalfPageDown)
 - **Tool Registry System** - Centralized tool registration and initialization using factory pattern
   - Created `pkg/tools/registry/` package with Registry interface and implementation
   - Factory pattern for tool creation with `ToolFactory` functions

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -186,13 +186,21 @@ func runOrchestratorHeadless(orch *orchestrator.Orchestrator, prompt string) {
 	fmt.Println(result.Result)
 }
 
-// runOrchestratorTUI runs orchestrator with TUI (placeholder)
+// runOrchestratorTUI runs orchestrator with TUI
 func runOrchestratorTUI(orch *orchestrator.Orchestrator, continueHistory bool) {
-	// TODO: Implement TUI integration with orchestrator
-	fmt.Println("🚧 Orchestrator TUI mode is not yet implemented.")
-	fmt.Println("Please use --headless mode with --prompt for now:")
-	fmt.Println("  ryan --orchestrate --headless --prompt 'your task here'")
-	os.Exit(0)
+	// Create agent wrapper to make orchestrator compatible with TUI
+	agentWrapper, err := orchestrator.NewAgentWrapper(orch)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating orchestrator wrapper: %v\n", err)
+		os.Exit(1)
+	}
+	defer agentWrapper.Close()
+
+	// Run TUI with the orchestrator wrapper
+	if err := tui.RunTUIWithOptions(agentWrapper, continueHistory); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func Execute() {

--- a/integration/orchestrator_routing_test.go
+++ b/integration/orchestrator_routing_test.go
@@ -1,0 +1,148 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/killallgit/ryan/pkg/ollama"
+	"github.com/killallgit/ryan/pkg/orchestrator"
+	"github.com/killallgit/ryan/pkg/orchestrator/agents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrchestratorRoutingFileOperations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Setup viper for test
+	setupViperForTest(t)
+
+	// Create LLM
+	ollamaClient := ollama.NewClient()
+	llm := ollamaClient.LLM
+
+	// Create orchestrator
+	orch, err := orchestrator.New(llm, orchestrator.WithMaxIterations(3))
+	require.NoError(t, err)
+
+	// Register real agents
+	err = agents.RegisterRealAgents(orch, llm, true) // skipPermissions = true
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		query          string
+		expectedAgent  string
+		shouldContain  string
+	}{
+		{
+			name:          "List files command",
+			query:         "list files in current directory",
+			expectedAgent: "tool_caller",
+			shouldContain: "ls",
+		},
+		{
+			name:          "Read file command",
+			query:         "read README.md file",
+			expectedAgent: "tool_caller",
+			shouldContain: "README",
+		},
+		{
+			name:          "Execute bash command",
+			query:         "run bash command pwd",
+			expectedAgent: "tool_caller",
+			shouldContain: "pwd",
+		},
+		{
+			name:          "Check directory",
+			query:         "check what's in the src folder",
+			expectedAgent: "tool_caller",
+			shouldContain: "src",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			// Execute the query
+			result, err := orch.Execute(ctx, tc.query)
+			require.NoError(t, err, "Should execute successfully")
+
+			// Check that we used the correct agent
+			foundExpectedAgent := false
+			for _, response := range result.History {
+				if string(response.AgentType) == tc.expectedAgent {
+					foundExpectedAgent = true
+					// Check if the response contains expected content
+					if tc.shouldContain != "" {
+						assert.Contains(t, response.Response, tc.shouldContain,
+							"Response should contain expected content")
+					}
+					break
+				}
+			}
+
+			assert.True(t, foundExpectedAgent,
+				"Should have used %s agent for query: %s", tc.expectedAgent, tc.query)
+		})
+	}
+}
+
+func TestOrchestratorIntentAnalysis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Setup viper for test
+	setupViperForTest(t)
+
+	// Create LLM
+	ollamaClient := ollama.NewClient()
+	llm := ollamaClient.LLM
+
+	orch, err := orchestrator.New(llm)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name         string
+		query        string
+		expectedType string
+	}{
+		{
+			name:         "File operation",
+			query:        "read a random file",
+			expectedType: "tool_use",
+		},
+		{
+			name:         "List files",
+			query:        "list all files",
+			expectedType: "tool_use",
+		},
+		{
+			name:         "Run command",
+			query:        "execute ls command",
+			expectedType: "tool_use",
+		},
+		{
+			name:         "Git operation",
+			query:        "check git status",
+			expectedType: "tool_use",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			intent, err := orch.AnalyzeIntent(ctx, tc.query)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedType, intent.Type,
+				"Query '%s' should be recognized as %s", tc.query, tc.expectedType)
+		})
+	}
+}

--- a/pkg/agent/executor_agent.go
+++ b/pkg/agent/executor_agent.go
@@ -229,7 +229,8 @@ func (e *ExecutorAgent) Execute(ctx context.Context, prompt string) (string, err
 		augmented, err := e.augmenter.AugmentPrompt(ctx, actualPrompt)
 		if err != nil {
 			// Log but don't fail - continue without augmentation
-			logger.Warn("Could not augment prompt: %v", err)
+			// This is common when vector store is empty, so use debug level
+			logger.Debug("Could not augment prompt (likely empty vector store): %v", err)
 		} else {
 			actualPrompt = augmented
 			logger.Debug("Prompt augmented successfully")
@@ -324,7 +325,8 @@ func (e *ExecutorAgent) ExecuteStream(ctx context.Context, prompt string, handle
 		augmented, err := e.augmenter.AugmentPrompt(ctx, actualPrompt)
 		if err != nil {
 			// Log but don't fail - continue without augmentation
-			logger.Warn("Could not augment prompt: %v", err)
+			// This is common when vector store is empty, so use debug level
+			logger.Debug("Could not augment prompt (likely empty vector store): %v", err)
 		} else {
 			actualPrompt = augmented
 			logger.Debug("Prompt augmented successfully (streaming)")

--- a/pkg/orchestrator/agent_wrapper.go
+++ b/pkg/orchestrator/agent_wrapper.go
@@ -63,11 +63,10 @@ func (w *AgentWrapper) Execute(ctx context.Context, prompt string) (string, erro
 func (w *AgentWrapper) ExecuteStream(ctx context.Context, prompt string, handler core.Handler) error {
 	logger.Debug("🎯 Orchestrator wrapper executing stream: %s", prompt)
 
-	// For now, we'll execute normally and stream the result
-	// Future enhancement: true streaming from orchestrator
-	result, err := w.orchestrator.Execute(ctx, prompt)
+	// Use the new streaming execution
+	result, err := w.orchestrator.ExecuteStream(ctx, prompt, handler)
 	if err != nil {
-		return fmt.Errorf("orchestrator execution failed: %w", err)
+		return fmt.Errorf("orchestrator streaming execution failed: %w", err)
 	}
 
 	// Save to history
@@ -77,23 +76,11 @@ func (w *AgentWrapper) ExecuteStream(ctx context.Context, prompt string, handler
 		}
 	}
 
-	// Update token stats
+	// Update token stats (approximate)
 	w.tokensSent += len(prompt) / 4
 	w.tokensReceived += len(result.Result) / 4
 
-	// Stream the formatted response
-	response := w.formatResponse(result)
-
-	// Send the response as chunks to simulate streaming
-	// This includes the routing information and result
-	lines := strings.Split(response, "\n")
-	for _, line := range lines {
-		if err := handler.OnChunk(line + "\n"); err != nil {
-			return err
-		}
-	}
-
-	return handler.OnComplete(response)
+	return nil
 }
 
 // formatResponse formats the orchestrator result for display

--- a/pkg/orchestrator/agent_wrapper.go
+++ b/pkg/orchestrator/agent_wrapper.go
@@ -1,0 +1,165 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/killallgit/ryan/pkg/logger"
+	"github.com/killallgit/ryan/pkg/stream/core"
+)
+
+// AgentWrapper wraps the Orchestrator to implement the agent.Agent interface
+// This allows the orchestrator to be used with the TUI
+type AgentWrapper struct {
+	orchestrator   *Orchestrator
+	historyManager *HistoryManager
+	tokensSent     int
+	tokensReceived int
+}
+
+// NewAgentWrapper creates a new orchestrator agent wrapper
+func NewAgentWrapper(orch *Orchestrator) (*AgentWrapper, error) {
+	historyManager, err := NewHistoryManager("orchestrator_tui_session")
+	if err != nil {
+		logger.Warn("Could not initialize history manager: %v", err)
+		// Continue without history - not critical for operation
+		historyManager = nil
+	}
+
+	return &AgentWrapper{
+		orchestrator:   orch,
+		historyManager: historyManager,
+	}, nil
+}
+
+// Execute handles a request and returns a response (blocking)
+func (w *AgentWrapper) Execute(ctx context.Context, prompt string) (string, error) {
+	logger.Debug("🎯 Orchestrator wrapper executing: %s", prompt)
+
+	// Execute through orchestrator
+	result, err := w.orchestrator.Execute(ctx, prompt)
+	if err != nil {
+		return "", fmt.Errorf("orchestrator execution failed: %w", err)
+	}
+
+	// Save to history
+	if w.historyManager != nil {
+		if err := w.historyManager.SaveTaskExecution(result); err != nil {
+			logger.Warn("Could not save task execution to history: %v", err)
+		}
+	}
+
+	// Update token stats (approximate - we don't have exact counts from orchestrator)
+	w.tokensSent += len(prompt) / 4 // Rough estimate
+	w.tokensReceived += len(result.Result) / 4
+
+	// Format the response to include routing information
+	response := w.formatResponse(result)
+	return response, nil
+}
+
+// ExecuteStream handles a request with streaming response
+func (w *AgentWrapper) ExecuteStream(ctx context.Context, prompt string, handler core.Handler) error {
+	logger.Debug("🎯 Orchestrator wrapper executing stream: %s", prompt)
+
+	// For now, we'll execute normally and stream the result
+	// Future enhancement: true streaming from orchestrator
+	result, err := w.orchestrator.Execute(ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("orchestrator execution failed: %w", err)
+	}
+
+	// Save to history
+	if w.historyManager != nil {
+		if err := w.historyManager.SaveTaskExecution(result); err != nil {
+			logger.Warn("Could not save task execution to history: %v", err)
+		}
+	}
+
+	// Update token stats
+	w.tokensSent += len(prompt) / 4
+	w.tokensReceived += len(result.Result) / 4
+
+	// Stream the formatted response
+	response := w.formatResponse(result)
+
+	// Send the response as chunks to simulate streaming
+	// This includes the routing information and result
+	lines := strings.Split(response, "\n")
+	for _, line := range lines {
+		if err := handler.OnChunk(line + "\n"); err != nil {
+			return err
+		}
+	}
+
+	return handler.OnComplete(response)
+}
+
+// formatResponse formats the orchestrator result for display
+func (w *AgentWrapper) formatResponse(result *TaskResult) string {
+	var sb strings.Builder
+
+	// Add routing header
+	sb.WriteString("🤖 **Orchestrator Routing Decision**\n\n")
+
+	// Show agent flow
+	if len(result.History) > 0 {
+		sb.WriteString("**Agent Flow:**\n")
+		for i, resp := range result.History {
+			emoji := "✅"
+			if resp.Status == "failed" {
+				emoji = "❌"
+			} else if resp.Status == "in_progress" {
+				emoji = "⏳"
+			}
+
+			sb.WriteString(fmt.Sprintf("%s %d. **%s** - %s\n",
+				emoji, i+1, resp.AgentType, resp.Status))
+
+			// Show tools used
+			if len(resp.ToolsCalled) > 0 {
+				sb.WriteString("   🔧 Tools: ")
+				toolNames := make([]string, len(resp.ToolsCalled))
+				for j, tool := range resp.ToolsCalled {
+					toolNames[j] = tool.Name
+				}
+				sb.WriteString(strings.Join(toolNames, ", "))
+				sb.WriteString("\n")
+			}
+
+			// Show error if any
+			if resp.Error != nil && *resp.Error != "" {
+				sb.WriteString(fmt.Sprintf("   ⚠️ Error: %s\n", *resp.Error))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Add the actual result
+	sb.WriteString("**Result:**\n")
+	sb.WriteString(result.Result)
+
+	return sb.String()
+}
+
+// ClearMemory clears the conversation memory
+func (w *AgentWrapper) ClearMemory() error {
+	if w.historyManager != nil {
+		return w.historyManager.Clear()
+	}
+	return nil
+}
+
+// GetTokenStats returns the cumulative token usage statistics
+func (w *AgentWrapper) GetTokenStats() (int, int) {
+	return w.tokensSent, w.tokensReceived
+}
+
+// Close cleans up resources
+func (w *AgentWrapper) Close() error {
+	if w.historyManager != nil {
+		return w.historyManager.Close()
+	}
+	return nil
+}

--- a/pkg/orchestrator/agent_wrapper_test.go
+++ b/pkg/orchestrator/agent_wrapper_test.go
@@ -1,0 +1,316 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentWrapper(t *testing.T) {
+	t.Run("creation and initialization", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		wrapper, err := NewAgentWrapper(orch)
+		assert.NoError(t, err)
+		assert.NotNil(t, wrapper)
+		assert.NotNil(t, wrapper.orchestrator)
+
+		// Cleanup
+		err = wrapper.Close()
+		assert.NoError(t, err)
+	})
+
+	t.Run("execute blocking", func(t *testing.T) {
+		// Setup orchestrator with mock
+		mockLLM := NewSimpleMockLLM()
+		mockLLM.WithIntentResponse(&TaskIntent{
+			Type:       "reasoning",
+			Confidence: 0.9,
+		})
+
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		// Register mock agent
+		mockAgent := NewSimpleMockAgent(AgentReasoner)
+		err = orch.RegisterAgent(AgentReasoner, mockAgent)
+		require.NoError(t, err)
+
+		// Create wrapper
+		wrapper, err := NewAgentWrapper(orch)
+		require.NoError(t, err)
+		defer wrapper.Close()
+
+		// Execute
+		ctx := context.Background()
+		response, err := wrapper.Execute(ctx, "Test query")
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, response)
+		assert.Contains(t, response, "Orchestrator Routing Decision")
+		assert.Contains(t, response, "Agent Flow")
+		assert.Contains(t, response, "Result")
+
+		// Check token stats updated
+		sent, received := wrapper.GetTokenStats()
+		assert.Greater(t, sent, 0)
+		assert.Greater(t, received, 0)
+	})
+
+	t.Run("execute streaming", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		mockLLM.WithIntentResponse(&TaskIntent{
+			Type:       "tool_use",
+			Confidence: 0.85,
+		})
+
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		mockAgent := NewSimpleMockAgent(AgentToolCaller)
+		err = orch.RegisterAgent(AgentToolCaller, mockAgent)
+		require.NoError(t, err)
+
+		wrapper, err := NewAgentWrapper(orch)
+		require.NoError(t, err)
+		defer wrapper.Close()
+
+		// Use mock stream handler
+		mockHandler := NewMockStreamHandler()
+
+		ctx := context.Background()
+		err = wrapper.ExecuteStream(ctx, "Stream test", mockHandler)
+
+		assert.NoError(t, err)
+
+		// Verify streaming occurred
+		assert.NotEmpty(t, mockHandler.chunks)
+		fullContent := mockHandler.GetFullContent()
+		assert.Contains(t, fullContent, "Orchestrator Processing")
+	})
+
+	t.Run("format response", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		wrapper, err := NewAgentWrapper(orch)
+		require.NoError(t, err)
+		defer wrapper.Close()
+
+		// Create a result with history
+		result := &TaskResult{
+			Query:  "Test",
+			Result: "Final result text",
+			History: []AgentResponse{
+				{
+					AgentType: AgentToolCaller,
+					Status:    "success",
+					Response:  "Tool response",
+					ToolsCalled: []ToolCall{
+						{Name: "bash", Arguments: map[string]interface{}{"command": "ls"}},
+					},
+					Timestamp: time.Now(),
+				},
+				{
+					AgentType: AgentReasoner,
+					Status:    "failed",
+					Response:  "Reasoning failed",
+					Error:     stringPtr("Test error"),
+					Timestamp: time.Now(),
+				},
+			},
+		}
+
+		formatted := wrapper.formatResponse(result)
+
+		// Check formatting
+		assert.Contains(t, formatted, "Orchestrator Routing Decision")
+		assert.Contains(t, formatted, "Agent Flow")
+		assert.Contains(t, formatted, "✅") // Success emoji
+		assert.Contains(t, formatted, "❌") // Failed emoji
+		assert.Contains(t, formatted, "tool_caller")
+		assert.Contains(t, formatted, "reasoner")
+		assert.Contains(t, formatted, "Tools: bash")
+		assert.Contains(t, formatted, "Error: Test error")
+		assert.Contains(t, formatted, "Final result text")
+	})
+
+	t.Run("clear memory", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		wrapper, err := NewAgentWrapper(orch)
+		require.NoError(t, err)
+		defer wrapper.Close()
+
+		// Clear memory should work even without history manager
+		err = wrapper.ClearMemory()
+		assert.NoError(t, err)
+	})
+
+	t.Run("token tracking", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		wrapper, err := NewAgentWrapper(orch)
+		require.NoError(t, err)
+		defer wrapper.Close()
+
+		// Initially zero
+		sent, received := wrapper.GetTokenStats()
+		assert.Equal(t, 0, sent)
+		assert.Equal(t, 0, received)
+
+		// Manually update for testing
+		wrapper.tokensSent = 100
+		wrapper.tokensReceived = 200
+
+		sent, received = wrapper.GetTokenStats()
+		assert.Equal(t, 100, sent)
+		assert.Equal(t, 200, received)
+	})
+
+	t.Run("handle orchestrator failure", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		// Don't set intent response, causing JSON parse error
+		mockLLM.responses = []string{"invalid json"}
+
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		wrapper, err := NewAgentWrapper(orch)
+		require.NoError(t, err)
+		defer wrapper.Close()
+
+		ctx := context.Background()
+		_, err = wrapper.Execute(ctx, "Test failure")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "orchestrator execution failed")
+	})
+}
+
+func TestAgentWrapperFormatResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *TaskResult
+		expected []string
+	}{
+		{
+			name: "empty history",
+			result: &TaskResult{
+				Result:  "Simple result",
+				History: []AgentResponse{},
+			},
+			expected: []string{
+				"Orchestrator Routing Decision",
+				"Result:",
+				"Simple result",
+			},
+		},
+		{
+			name: "with in_progress status",
+			result: &TaskResult{
+				Result: "In progress",
+				History: []AgentResponse{
+					{
+						AgentType: AgentPlanner,
+						Status:    "in_progress",
+					},
+				},
+			},
+			expected: []string{
+				"⏳", // In progress emoji
+				"planner",
+			},
+		},
+		{
+			name: "multiple tools called",
+			result: &TaskResult{
+				Result: "Done",
+				History: []AgentResponse{
+					{
+						AgentType: AgentToolCaller,
+						Status:    "success",
+						ToolsCalled: []ToolCall{
+							{Name: "bash"},
+							{Name: "git"},
+							{Name: "file_read"},
+						},
+					},
+				},
+			},
+			expected: []string{
+				"Tools: bash, git, file_read",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLLM := NewSimpleMockLLM()
+			orch, _ := New(mockLLM)
+			wrapper, _ := NewAgentWrapper(orch)
+			defer wrapper.Close()
+
+			formatted := wrapper.formatResponse(tt.result)
+
+			for _, expected := range tt.expected {
+				assert.Contains(t, formatted, expected)
+			}
+		})
+	}
+}
+
+func TestAgentWrapperIntegration(t *testing.T) {
+	t.Run("full execution flow", func(t *testing.T) {
+		// Create a more complex mock scenario
+		mockLLM := NewSimpleMockLLM()
+		mockLLM.WithIntentResponse(&TaskIntent{
+			Type:                 "tool_use",
+			Confidence:           0.95,
+			RequiredCapabilities: []string{"bash_commands"},
+		})
+
+		orch, err := New(mockLLM, WithMaxIterations(3))
+		require.NoError(t, err)
+
+		// Register multiple agents
+		toolAgent := NewSimpleMockAgent(AgentToolCaller)
+		reasonerAgent := NewSimpleMockAgent(AgentReasoner)
+
+		err = orch.RegisterAgent(AgentToolCaller, toolAgent)
+		require.NoError(t, err)
+		err = orch.RegisterAgent(AgentReasoner, reasonerAgent)
+		require.NoError(t, err)
+
+		wrapper, err := NewAgentWrapper(orch)
+		require.NoError(t, err)
+		defer wrapper.Close()
+
+		// Execute and verify
+		ctx := context.Background()
+		response, err := wrapper.Execute(ctx, "Run ls command")
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, response)
+
+		// Verify formatted output structure
+		lines := strings.Split(response, "\n")
+		assert.Greater(t, len(lines), 5) // Should have multiple lines of output
+
+		// Check for key sections
+		assert.Contains(t, response, "Orchestrator Routing Decision")
+		assert.Contains(t, response, "Agent Flow")
+		assert.Contains(t, response, "Result")
+	})
+}

--- a/pkg/orchestrator/agent_wrapper_test.go
+++ b/pkg/orchestrator/agent_wrapper_test.go
@@ -92,7 +92,8 @@ func TestAgentWrapper(t *testing.T) {
 		// Verify streaming occurred
 		assert.NotEmpty(t, mockHandler.chunks)
 		fullContent := mockHandler.GetFullContent()
-		assert.Contains(t, fullContent, "Orchestrator Processing")
+		// We removed the verbose messages, check for agent marker
+		assert.Contains(t, fullContent, "[tool_caller]")
 	})
 
 	t.Run("format response", func(t *testing.T) {

--- a/pkg/orchestrator/agents/factory.go
+++ b/pkg/orchestrator/agents/factory.go
@@ -1,0 +1,50 @@
+package agents
+
+import (
+	"github.com/killallgit/ryan/pkg/logger"
+	"github.com/killallgit/ryan/pkg/orchestrator"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// RegisterRealAgents registers all real agent implementations with the orchestrator
+func RegisterRealAgents(orch *orchestrator.Orchestrator, llm llms.Model, skipPermissions bool) error {
+	logger.Info("Registering real agents with orchestrator")
+
+	// Create and register tool caller agent
+	toolCaller := NewToolCallerAgent(llm, skipPermissions)
+	if err := orch.RegisterAgent(orchestrator.AgentToolCaller, toolCaller); err != nil {
+		return err
+	}
+	logger.Debug("Registered ToolCallerAgent")
+
+	// Create and register reasoner agent
+	reasoner := NewReasonerAgent(llm)
+	if err := orch.RegisterAgent(orchestrator.AgentReasoner, reasoner); err != nil {
+		return err
+	}
+	logger.Debug("Registered ReasonerAgent")
+
+	// Create and register code generation agent
+	codeGen := NewCodeGenAgent(llm)
+	if err := orch.RegisterAgent(orchestrator.AgentCodeGen, codeGen); err != nil {
+		return err
+	}
+	logger.Debug("Registered CodeGenAgent")
+
+	// Create and register searcher agent
+	searcher := NewSearcherAgent(llm, skipPermissions)
+	if err := orch.RegisterAgent(orchestrator.AgentSearcher, searcher); err != nil {
+		return err
+	}
+	logger.Debug("Registered SearcherAgent")
+
+	// Create and register planner agent
+	planner := NewPlannerAgent(llm)
+	if err := orch.RegisterAgent(orchestrator.AgentPlanner, planner); err != nil {
+		return err
+	}
+	logger.Debug("Registered PlannerAgent")
+
+	logger.Info("Successfully registered 5 real agents")
+	return nil
+}

--- a/pkg/orchestrator/agents/planner_enhanced.go
+++ b/pkg/orchestrator/agents/planner_enhanced.go
@@ -1,0 +1,360 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/killallgit/ryan/pkg/logger"
+	"github.com/killallgit/ryan/pkg/orchestrator"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// EnhancedPlannerAgent creates structured plans with NextAction suggestions
+type EnhancedPlannerAgent struct {
+	llm llms.Model
+}
+
+// NewEnhancedPlannerAgent creates a new enhanced planner agent
+func NewEnhancedPlannerAgent(llm llms.Model) *EnhancedPlannerAgent {
+	return &EnhancedPlannerAgent{llm: llm}
+}
+
+// Execute implements the Agent interface with structured planning
+func (p *EnhancedPlannerAgent) Execute(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	logger.Debug("EnhancedPlannerAgent executing: %s", decision.Instruction)
+
+	// Check if we should create a structured plan
+	if shouldCreateStructuredPlan(decision) {
+		return p.executeStructuredPlanning(ctx, decision, state)
+	}
+
+	// Fall back to simple planning
+	return p.executeSimplePlanning(ctx, decision, state)
+}
+
+// executeStructuredPlanning creates a structured TaskPlan
+func (p *EnhancedPlannerAgent) executeStructuredPlanning(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	prompt := fmt.Sprintf(`You are a planning agent that creates structured, executable plans.
+
+Task: %s
+
+Create a JSON plan with the following structure:
+{
+  "name": "Brief plan name",
+  "description": "Plan description",
+  "tasks": [
+    {
+      "id": "task_1",
+      "name": "Task name",
+      "description": "What this task does",
+      "agent_type": "tool_caller|code_gen|reasoner|searcher",
+      "input": "Specific instruction for the agent",
+      "expected_output": "What we expect from this task"
+    }
+  ],
+  "dependencies": {
+    "task_2": ["task_1"],  // task_2 depends on task_1
+    "task_3": ["task_1", "task_2"]  // task_3 depends on both
+  }
+}
+
+Important guidelines:
+1. Break down the task into 3-7 concrete, actionable steps
+2. Choose the right agent for each task:
+   - tool_caller: For file operations, bash commands, git operations
+   - code_gen: For writing or modifying code
+   - reasoner: For analysis, debugging, or decision making
+   - searcher: For finding code, documentation, or examples
+3. Set up dependencies correctly - tasks that need output from others should depend on them
+4. Make inputs specific and actionable
+5. The first task should be immediately executable
+
+Task to plan: %s`, decision.Instruction, decision.Instruction)
+
+	response, err := p.llm.Call(ctx, prompt)
+	if err != nil {
+		return p.createErrorResponse(fmt.Errorf("planning failed: %w", err))
+	}
+
+	// Try to parse the JSON plan
+	plan, err := p.parseJSONPlan(response)
+	if err != nil {
+		logger.Warn("Failed to parse structured plan, falling back to text: %v", err)
+		return p.createTextResponse(response, decision, state)
+	}
+
+	// Store the plan in state metadata
+	if state.Metadata == nil {
+		state.Metadata = make(map[string]interface{})
+	}
+	state.Metadata["task_plan"] = plan
+
+	// Create response with NextAction for the first task
+	var nextAction *orchestrator.RouteDecision
+	if len(plan.Tasks) > 0 {
+		firstTask := plan.Tasks[0]
+		nextAction = &orchestrator.RouteDecision{
+			TargetAgent: firstTask.AgentType,
+			Instruction: firstTask.Input,
+			Parameters: map[string]interface{}{
+				"task_id":   firstTask.ID,
+				"task_name": firstTask.Name,
+			},
+		}
+		logger.Info("📋 Created structured plan with %d tasks, suggesting first: %s",
+			len(plan.Tasks), firstTask.Name)
+	}
+
+	// Format the plan for display
+	planSummary := p.formatPlanSummary(plan)
+
+	return &orchestrator.AgentResponse{
+		AgentType:  orchestrator.AgentPlanner,
+		Status:     "success",
+		Response:   planSummary,
+		NextAction: nextAction,
+		Timestamp:  time.Now(),
+	}, nil
+}
+
+// executeSimplePlanning creates a simple text-based plan
+func (p *EnhancedPlannerAgent) executeSimplePlanning(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	prompt := fmt.Sprintf(`You are a planning agent specialized in breaking down complex tasks.
+
+Task: %s
+
+Create a clear, actionable plan with:
+1. Task analysis and requirements
+2. Step-by-step breakdown (3-7 steps)
+3. Dependencies between steps
+4. Recommended agent for each step (tool_caller, code_gen, reasoner, or searcher)
+5. Success criteria
+
+After the plan, suggest the FIRST concrete action to take.
+Format: "FIRST ACTION: [agent_type] - [specific instruction]"`, decision.Instruction)
+
+	response, err := p.llm.Call(ctx, prompt)
+	if err != nil {
+		return p.createErrorResponse(fmt.Errorf("planning failed: %w", err))
+	}
+
+	// Extract first action if present
+	nextAction := p.extractFirstAction(response)
+
+	return &orchestrator.AgentResponse{
+		AgentType:  orchestrator.AgentPlanner,
+		Status:     "success",
+		Response:   response,
+		NextAction: nextAction,
+		Timestamp:  time.Now(),
+	}, nil
+}
+
+// parseJSONPlan attempts to parse a JSON plan from the response
+func (p *EnhancedPlannerAgent) parseJSONPlan(response string) (*orchestrator.TaskPlan, error) {
+	// Extract JSON from the response (might be wrapped in markdown or text)
+	jsonStart := strings.Index(response, "{")
+	jsonEnd := strings.LastIndex(response, "}")
+
+	if jsonStart == -1 || jsonEnd == -1 || jsonEnd <= jsonStart {
+		return nil, fmt.Errorf("no JSON found in response")
+	}
+
+	jsonStr := response[jsonStart : jsonEnd+1]
+
+	// Parse into a temporary structure
+	var planData struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Tasks       []struct {
+			ID             string `json:"id"`
+			Name           string `json:"name"`
+			Description    string `json:"description"`
+			AgentType      string `json:"agent_type"`
+			Input          string `json:"input"`
+			ExpectedOutput string `json:"expected_output"`
+		} `json:"tasks"`
+		Dependencies map[string][]string `json:"dependencies"`
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &planData); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	// Convert to TaskPlan
+	plan := orchestrator.NewTaskPlan(planData.Name, planData.Description)
+
+	// Add tasks
+	for _, taskData := range planData.Tasks {
+		task := orchestrator.SubTask{
+			ID:             taskData.ID,
+			Name:           taskData.Name,
+			Description:    taskData.Description,
+			AgentType:      p.parseAgentType(taskData.AgentType),
+			Input:          taskData.Input,
+			ExpectedOutput: taskData.ExpectedOutput,
+			Status:         orchestrator.TaskStatusPending,
+			Metadata:       make(map[string]interface{}),
+		}
+		plan.AddTask(task)
+	}
+
+	// Add dependencies
+	for taskID, deps := range planData.Dependencies {
+		plan.AddDependency(taskID, deps...)
+	}
+
+	return plan, nil
+}
+
+// parseAgentType converts string to AgentType
+func (p *EnhancedPlannerAgent) parseAgentType(agentStr string) orchestrator.AgentType {
+	switch strings.ToLower(strings.TrimSpace(agentStr)) {
+	case "tool_caller", "tool":
+		return orchestrator.AgentToolCaller
+	case "code_gen", "code", "codegen":
+		return orchestrator.AgentCodeGen
+	case "reasoner", "reason":
+		return orchestrator.AgentReasoner
+	case "searcher", "search":
+		return orchestrator.AgentSearcher
+	case "planner", "plan":
+		return orchestrator.AgentPlanner
+	default:
+		return orchestrator.AgentReasoner // Default fallback
+	}
+}
+
+// extractFirstAction extracts a NextAction from text response
+func (p *EnhancedPlannerAgent) extractFirstAction(response string) *orchestrator.RouteDecision {
+	// Look for "FIRST ACTION:" pattern
+	lines := strings.Split(response, "\n")
+	for _, line := range lines {
+		if strings.Contains(strings.ToUpper(line), "FIRST ACTION:") {
+			// Parse the action
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) < 2 {
+				continue
+			}
+
+			actionStr := strings.TrimSpace(parts[1])
+			// Try to parse "agent_type - instruction" format
+			actionParts := strings.SplitN(actionStr, "-", 2)
+			if len(actionParts) >= 2 {
+				agentType := p.parseAgentType(strings.TrimSpace(actionParts[0]))
+				instruction := strings.TrimSpace(actionParts[1])
+
+				return &orchestrator.RouteDecision{
+					TargetAgent: agentType,
+					Instruction: instruction,
+				}
+			}
+		}
+	}
+
+	// Try to infer from the plan content
+	if strings.Contains(response, "search") || strings.Contains(response, "find") {
+		if idx := strings.Index(response, "Step 1:"); idx != -1 {
+			stepOne := response[idx:min(idx+200, len(response))]
+			return &orchestrator.RouteDecision{
+				TargetAgent: orchestrator.AgentSearcher,
+				Instruction: stepOne,
+			}
+		}
+	}
+
+	return nil
+}
+
+// formatPlanSummary creates a readable summary of the plan
+func (p *EnhancedPlannerAgent) formatPlanSummary(plan *orchestrator.TaskPlan) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("📋 **Structured Plan: %s**\n\n", plan.Name))
+	sb.WriteString(fmt.Sprintf("*%s*\n\n", plan.Description))
+	sb.WriteString(fmt.Sprintf("**Tasks (%d):**\n", len(plan.Tasks)))
+
+	for i, task := range plan.Tasks {
+		deps := ""
+		if taskDeps, hasDeps := plan.Dependencies[task.ID]; hasDeps && len(taskDeps) > 0 {
+			deps = fmt.Sprintf(" (depends on: %s)", strings.Join(taskDeps, ", "))
+		}
+
+		sb.WriteString(fmt.Sprintf("%d. **%s** [%s]%s\n",
+			i+1, task.Name, task.AgentType, deps))
+		sb.WriteString(fmt.Sprintf("   - %s\n", task.Description))
+		if task.ExpectedOutput != "" {
+			sb.WriteString(fmt.Sprintf("   - Expected: %s\n", task.ExpectedOutput))
+		}
+	}
+
+	return sb.String()
+}
+
+// shouldCreateStructuredPlan determines if we should create a structured plan
+func shouldCreateStructuredPlan(decision *orchestrator.RouteDecision) bool {
+	// Check for keywords that indicate complex multi-step tasks
+	keywords := []string{
+		"refactor", "implement", "create", "build", "analyze and",
+		"step by step", "workflow", "pipeline", "multiple",
+	}
+
+	instruction := strings.ToLower(decision.Instruction)
+	for _, keyword := range keywords {
+		if strings.Contains(instruction, keyword) {
+			return true
+		}
+	}
+
+	// Check if explicitly requested
+	if params, ok := decision.Parameters["structured_plan"].(bool); ok && params {
+		return true
+	}
+
+	return false
+}
+
+// createErrorResponse creates an error response
+func (p *EnhancedPlannerAgent) createErrorResponse(err error) (*orchestrator.AgentResponse, error) {
+	errorStr := err.Error()
+	return &orchestrator.AgentResponse{
+		AgentType: orchestrator.AgentPlanner,
+		Status:    "failed",
+		Error:     &errorStr,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+// createTextResponse creates a simple text response
+func (p *EnhancedPlannerAgent) createTextResponse(response string, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	nextAction := p.extractFirstAction(response)
+
+	return &orchestrator.AgentResponse{
+		AgentType:  orchestrator.AgentPlanner,
+		Status:     "success",
+		Response:   response,
+		NextAction: nextAction,
+		Timestamp:  time.Now(),
+	}, nil
+}
+
+// GetCapabilities implements the Agent interface
+func (p *EnhancedPlannerAgent) GetCapabilities() []string {
+	return []string{"planning", "decomposition", "strategy", "organization", "structured_planning"}
+}
+
+// GetType implements the Agent interface
+func (p *EnhancedPlannerAgent) GetType() orchestrator.AgentType {
+	return orchestrator.AgentPlanner
+}
+
+// min returns the minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/orchestrator/agents/real_agents.go
+++ b/pkg/orchestrator/agents/real_agents.go
@@ -1,0 +1,512 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/killallgit/ryan/pkg/logger"
+	"github.com/killallgit/ryan/pkg/orchestrator"
+	ryantools "github.com/killallgit/ryan/pkg/tools"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// ToolInterface defines the interface for tools that can be called
+type ToolInterface interface {
+	Call(ctx context.Context, input string) (string, error)
+	Name() string
+	Description() string
+}
+
+// ToolCallerAgent handles tool execution and function calls
+type ToolCallerAgent struct {
+	llm             llms.Model
+	availableTools  map[string]ToolInterface
+	skipPermissions bool
+}
+
+// NewToolCallerAgent creates a new tool caller agent
+func NewToolCallerAgent(llm llms.Model, skipPermissions bool) *ToolCallerAgent {
+	agent := &ToolCallerAgent{
+		llm:             llm,
+		availableTools:  make(map[string]ToolInterface),
+		skipPermissions: skipPermissions,
+	}
+
+	// Initialize available tools
+	agent.initializeTools()
+	return agent
+}
+
+// initializeTools sets up the available tools
+func (t *ToolCallerAgent) initializeTools() {
+	// Add all available tools
+	t.availableTools["bash"] = ryantools.NewBashToolWithBypass(t.skipPermissions)
+	t.availableTools["file_read"] = ryantools.NewFileReadToolWithBypass(t.skipPermissions)
+	t.availableTools["file_write"] = ryantools.NewFileWriteToolWithBypass(t.skipPermissions)
+	t.availableTools["git"] = ryantools.NewGitToolWithBypass(t.skipPermissions)
+	t.availableTools["search"] = ryantools.NewRipgrepToolWithBypass(t.skipPermissions)
+	t.availableTools["web"] = ryantools.NewWebFetchToolWithBypass(t.skipPermissions)
+
+	logger.Info("ToolCallerAgent initialized with %d tools", len(t.availableTools))
+}
+
+// Execute implements the Agent interface
+func (t *ToolCallerAgent) Execute(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	logger.Debug("ToolCallerAgent executing: %s", decision.Instruction)
+
+	// Create prompt for tool usage analysis
+	toolsJson, _ := json.Marshal(t.getToolDescriptions())
+	prompt := fmt.Sprintf(`You are a tool caller agent. Analyze the following instruction and determine which tools to use and how to use them.
+
+Available tools: %s
+
+Instruction: %s
+
+Please provide a structured response with:
+1. Which tools to call and with what arguments
+2. The execution plan
+3. Expected results
+
+Respond in the following JSON format:
+{
+  "plan": "explanation of what you'll do",
+  "tool_calls": [
+    {
+      "tool": "tool_name",
+      "description": "what this call will do",
+      "arguments": {"arg1": "value1"}
+    }
+  ]
+}`, toolsJson, decision.Instruction)
+
+	// Get LLM response for planning
+	planResponse, err := t.llm.Call(ctx, prompt)
+	if err != nil {
+		return &orchestrator.AgentResponse{
+			AgentType: orchestrator.AgentToolCaller,
+			Status:    "failed",
+			Error:     &[]string{fmt.Sprintf("Failed to plan tool usage: %v", err)}[0],
+			Timestamp: time.Now(),
+		}, nil
+	}
+
+	// Parse the plan
+	var plan struct {
+		Plan      string `json:"plan"`
+		ToolCalls []struct {
+			Tool        string                 `json:"tool"`
+			Description string                 `json:"description"`
+			Arguments   map[string]interface{} `json:"arguments"`
+		} `json:"tool_calls"`
+	}
+
+	if err := json.Unmarshal([]byte(planResponse), &plan); err != nil {
+		// If JSON parsing fails, try to extract tool calls from the text response
+		logger.Warn("Failed to parse JSON plan, attempting text analysis: %v", err)
+		return t.executeWithTextAnalysis(ctx, decision, planResponse)
+	}
+
+	// Execute the planned tool calls
+	var toolCalls []orchestrator.ToolCall
+	var results []string
+	var hasError bool
+	var errorMsg string
+
+	results = append(results, fmt.Sprintf("Plan: %s\n", plan.Plan))
+
+	for _, toolCall := range plan.ToolCalls {
+		logger.Debug("Executing tool: %s with args: %v", toolCall.Tool, toolCall.Arguments)
+
+		tool, exists := t.availableTools[toolCall.Tool]
+		if !exists {
+			errorMsg = fmt.Sprintf("Tool %s not available", toolCall.Tool)
+			hasError = true
+			break
+		}
+
+		// Execute the tool
+		result, err := t.executeTool(ctx, tool, toolCall.Arguments)
+		if err != nil {
+			errorMsg = fmt.Sprintf("Tool %s failed: %v", toolCall.Tool, err)
+			hasError = true
+			break
+		}
+
+		toolCalls = append(toolCalls, orchestrator.ToolCall{
+			Name:      toolCall.Tool,
+			Arguments: toolCall.Arguments,
+			Result:    result,
+		})
+
+		results = append(results, fmt.Sprintf("%s: %s", toolCall.Description, result))
+	}
+
+	// Build response
+	response := &orchestrator.AgentResponse{
+		AgentType:   orchestrator.AgentToolCaller,
+		ToolsCalled: toolCalls,
+		Timestamp:   time.Now(),
+	}
+
+	if hasError {
+		response.Status = "failed"
+		response.Error = &errorMsg
+		response.Response = strings.Join(results, "\n")
+	} else {
+		response.Status = "success"
+		response.Response = strings.Join(results, "\n")
+	}
+
+	return response, nil
+}
+
+// executeWithTextAnalysis handles cases where JSON parsing failed
+func (t *ToolCallerAgent) executeWithTextAnalysis(ctx context.Context, decision *orchestrator.RouteDecision, llmResponse string) (*orchestrator.AgentResponse, error) {
+	// Simple heuristic-based tool selection based on instruction content
+	instruction := strings.ToLower(decision.Instruction)
+	var selectedTool ToolInterface
+	var toolName string
+	var args map[string]interface{}
+
+	if strings.Contains(instruction, "list") && strings.Contains(instruction, "file") {
+		selectedTool = t.availableTools["bash"]
+		toolName = "bash"
+		args = map[string]interface{}{"command": "ls -la"}
+	} else if strings.Contains(instruction, "read") && strings.Contains(instruction, "file") {
+		selectedTool = t.availableTools["file_read"]
+		toolName = "file_read"
+		// Try to extract filename from instruction
+		args = map[string]interface{}{"path": "."} // Default to current directory
+	} else if strings.Contains(instruction, "search") || strings.Contains(instruction, "find") {
+		selectedTool = t.availableTools["search"]
+		toolName = "search"
+		args = map[string]interface{}{"pattern": ".*"} // Default pattern
+	} else {
+		// Default to bash for general commands
+		selectedTool = t.availableTools["bash"]
+		toolName = "bash"
+		args = map[string]interface{}{"command": "echo 'Tool analysis needed'"}
+	}
+
+	// Execute the selected tool
+	result, err := t.executeTool(ctx, selectedTool, args)
+	if err != nil {
+		errorStr := fmt.Sprintf("Tool execution failed: %v", err)
+		return &orchestrator.AgentResponse{
+			AgentType: orchestrator.AgentToolCaller,
+			Status:    "failed",
+			Error:     &errorStr,
+			Response:  llmResponse,
+			Timestamp: time.Now(),
+		}, nil
+	}
+
+	return &orchestrator.AgentResponse{
+		AgentType: orchestrator.AgentToolCaller,
+		Status:    "success",
+		Response:  fmt.Sprintf("Executed %s: %s", toolName, result),
+		ToolsCalled: []orchestrator.ToolCall{
+			{
+				Name:      toolName,
+				Arguments: args,
+				Result:    result,
+			},
+		},
+		Timestamp: time.Now(),
+	}, nil
+}
+
+// executeTool executes a specific tool with given arguments
+func (t *ToolCallerAgent) executeTool(ctx context.Context, tool ToolInterface, args map[string]interface{}) (string, error) {
+	// Convert args to the format expected by the tool
+	// For now, we'll just pass the arguments as a string representation
+	// In a real implementation, we'd parse the arguments properly for each tool
+
+	var input string
+	if cmd, ok := args["command"].(string); ok {
+		input = cmd
+	} else if path, ok := args["path"].(string); ok {
+		input = path
+	} else if pattern, ok := args["pattern"].(string); ok {
+		input = pattern
+	} else if query, ok := args["query"].(string); ok {
+		input = query
+	} else {
+		input = fmt.Sprintf("%v", args)
+	}
+
+	return tool.Call(ctx, input)
+}
+
+// getToolDescriptions returns descriptions of available tools
+func (t *ToolCallerAgent) getToolDescriptions() map[string]string {
+	return map[string]string{
+		"bash":       "Execute shell commands",
+		"file_read":  "Read file contents",
+		"file_write": "Write content to files",
+		"git":        "Git version control operations",
+		"search":     "Search through files and code",
+		"web":        "Fetch content from web URLs",
+	}
+}
+
+// GetCapabilities implements the Agent interface
+func (t *ToolCallerAgent) GetCapabilities() []string {
+	capabilities := make([]string, 0, len(t.availableTools))
+	for name := range t.availableTools {
+		capabilities = append(capabilities, name)
+	}
+	return capabilities
+}
+
+// GetType implements the Agent interface
+func (t *ToolCallerAgent) GetType() orchestrator.AgentType {
+	return orchestrator.AgentToolCaller
+}
+
+// ReasonerAgent handles complex reasoning and analysis
+type ReasonerAgent struct {
+	llm llms.Model
+}
+
+// NewReasonerAgent creates a new reasoner agent
+func NewReasonerAgent(llm llms.Model) *ReasonerAgent {
+	return &ReasonerAgent{llm: llm}
+}
+
+// Execute implements the Agent interface
+func (r *ReasonerAgent) Execute(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	logger.Debug("ReasonerAgent executing: %s", decision.Instruction)
+
+	// Create a reasoning-focused prompt
+	prompt := fmt.Sprintf(`You are a reasoning agent specialized in analysis, problem-solving, and logical thinking.
+
+Task: %s
+
+Please provide a thorough analysis with:
+1. Problem understanding
+2. Key considerations
+3. Step-by-step reasoning
+4. Conclusions and recommendations
+
+Be detailed and explain your reasoning process.`, decision.Instruction)
+
+	response, err := r.llm.Call(ctx, prompt)
+	if err != nil {
+		errorStr := fmt.Sprintf("Reasoning failed: %v", err)
+		return &orchestrator.AgentResponse{
+			AgentType: orchestrator.AgentReasoner,
+			Status:    "failed",
+			Error:     &errorStr,
+			Timestamp: time.Now(),
+		}, nil
+	}
+
+	return &orchestrator.AgentResponse{
+		AgentType: orchestrator.AgentReasoner,
+		Status:    "success",
+		Response:  response,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+// GetCapabilities implements the Agent interface
+func (r *ReasonerAgent) GetCapabilities() []string {
+	return []string{"reasoning", "analysis", "problem-solving", "logic"}
+}
+
+// GetType implements the Agent interface
+func (r *ReasonerAgent) GetType() orchestrator.AgentType {
+	return orchestrator.AgentReasoner
+}
+
+// CodeGenAgent handles code generation tasks
+type CodeGenAgent struct {
+	llm llms.Model
+}
+
+// NewCodeGenAgent creates a new code generation agent
+func NewCodeGenAgent(llm llms.Model) *CodeGenAgent {
+	return &CodeGenAgent{llm: llm}
+}
+
+// Execute implements the Agent interface
+func (c *CodeGenAgent) Execute(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	logger.Debug("CodeGenAgent executing: %s", decision.Instruction)
+
+	prompt := fmt.Sprintf(`You are a code generation agent specialized in writing high-quality, well-documented code.
+
+Task: %s
+
+Please provide:
+1. Clean, well-structured code
+2. Appropriate comments and documentation
+3. Follow best practices for the language
+4. Include error handling where appropriate
+
+Format your response with proper code blocks and explanations.`, decision.Instruction)
+
+	response, err := c.llm.Call(ctx, prompt)
+	if err != nil {
+		errorStr := fmt.Sprintf("Code generation failed: %v", err)
+		return &orchestrator.AgentResponse{
+			AgentType: orchestrator.AgentCodeGen,
+			Status:    "failed",
+			Error:     &errorStr,
+			Timestamp: time.Now(),
+		}, nil
+	}
+
+	return &orchestrator.AgentResponse{
+		AgentType: orchestrator.AgentCodeGen,
+		Status:    "success",
+		Response:  response,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+// GetCapabilities implements the Agent interface
+func (c *CodeGenAgent) GetCapabilities() []string {
+	return []string{"coding", "programming", "implementation", "refactoring"}
+}
+
+// GetType implements the Agent interface
+func (c *CodeGenAgent) GetType() orchestrator.AgentType {
+	return orchestrator.AgentCodeGen
+}
+
+// SearcherAgent handles search and code analysis tasks
+type SearcherAgent struct {
+	llm        llms.Model
+	searchTool ToolInterface
+}
+
+// NewSearcherAgent creates a new searcher agent
+func NewSearcherAgent(llm llms.Model, skipPermissions bool) *SearcherAgent {
+	return &SearcherAgent{
+		llm:        llm,
+		searchTool: ryantools.NewRipgrepToolWithBypass(skipPermissions),
+	}
+}
+
+// Execute implements the Agent interface
+func (s *SearcherAgent) Execute(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	logger.Debug("SearcherAgent executing: %s", decision.Instruction)
+
+	// First, analyze what to search for
+	prompt := fmt.Sprintf(`You are a search agent. Analyze the following request and determine the best search strategy.
+
+Request: %s
+
+Determine:
+1. What patterns or terms to search for
+2. What file types to focus on
+3. What search strategy would be most effective
+
+Provide your search plan and then I'll execute it.`, decision.Instruction)
+
+	planResponse, err := s.llm.Call(ctx, prompt)
+	if err != nil {
+		errorStr := fmt.Sprintf("Search planning failed: %v", err)
+		return &orchestrator.AgentResponse{
+			AgentType: orchestrator.AgentSearcher,
+			Status:    "failed",
+			Error:     &errorStr,
+			Timestamp: time.Now(),
+		}, nil
+	}
+
+	// Execute search (simplified for now - in reality would parse the plan)
+	searchResult, err := s.searchTool.Call(ctx, decision.Instruction)
+	if err != nil {
+		logger.Warn("Search tool failed: %v", err)
+		searchResult = "Search could not be completed"
+	}
+
+	response := fmt.Sprintf("Search Plan:\n%s\n\nSearch Results:\n%s", planResponse, searchResult)
+
+	return &orchestrator.AgentResponse{
+		AgentType: orchestrator.AgentSearcher,
+		Status:    "success",
+		Response:  response,
+		ToolsCalled: []orchestrator.ToolCall{
+			{
+				Name:      "search",
+				Arguments: map[string]interface{}{"query": decision.Instruction},
+				Result:    searchResult,
+			},
+		},
+		Timestamp: time.Now(),
+	}, nil
+}
+
+// GetCapabilities implements the Agent interface
+func (s *SearcherAgent) GetCapabilities() []string {
+	return []string{"search", "find", "locate", "analysis"}
+}
+
+// GetType implements the Agent interface
+func (s *SearcherAgent) GetType() orchestrator.AgentType {
+	return orchestrator.AgentSearcher
+}
+
+// PlannerAgent handles task planning and decomposition
+type PlannerAgent struct {
+	llm llms.Model
+}
+
+// NewPlannerAgent creates a new planner agent
+func NewPlannerAgent(llm llms.Model) *PlannerAgent {
+	return &PlannerAgent{llm: llm}
+}
+
+// Execute implements the Agent interface
+func (p *PlannerAgent) Execute(ctx context.Context, decision *orchestrator.RouteDecision, state *orchestrator.TaskState) (*orchestrator.AgentResponse, error) {
+	logger.Debug("PlannerAgent executing: %s", decision.Instruction)
+
+	prompt := fmt.Sprintf(`You are a planning agent specialized in breaking down complex tasks into manageable steps.
+
+Task: %s
+
+Please create a detailed plan with:
+1. Task analysis and requirements
+2. Step-by-step breakdown
+3. Dependencies between steps
+4. Recommended tools or approaches for each step
+5. Success criteria
+
+Also suggest which specialized agents might be needed for each step (tool_caller, code_gen, reasoner, searcher).`, decision.Instruction)
+
+	response, err := p.llm.Call(ctx, prompt)
+	if err != nil {
+		errorStr := fmt.Sprintf("Planning failed: %v", err)
+		return &orchestrator.AgentResponse{
+			AgentType: orchestrator.AgentPlanner,
+			Status:    "failed",
+			Error:     &errorStr,
+			Timestamp: time.Now(),
+		}, nil
+	}
+
+	// For now, don't suggest next actions - let the orchestrator handle the flow
+	// In future, could parse the plan and suggest the first step
+	return &orchestrator.AgentResponse{
+		AgentType: orchestrator.AgentPlanner,
+		Status:    "success",
+		Response:  response,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+// GetCapabilities implements the Agent interface
+func (p *PlannerAgent) GetCapabilities() []string {
+	return []string{"planning", "decomposition", "strategy", "organization"}
+}
+
+// GetType implements the Agent interface
+func (p *PlannerAgent) GetType() orchestrator.AgentType {
+	return orchestrator.AgentPlanner
+}

--- a/pkg/orchestrator/chain_executor.go
+++ b/pkg/orchestrator/chain_executor.go
@@ -1,0 +1,262 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/killallgit/ryan/pkg/logger"
+)
+
+// ChainExecutor handles the execution of task plans with proper sequencing
+type ChainExecutor struct {
+	orchestrator *Orchestrator
+	plan         *TaskPlan
+	state        *TaskState
+}
+
+// NewChainExecutor creates a new chain executor
+func NewChainExecutor(orchestrator *Orchestrator) *ChainExecutor {
+	return &ChainExecutor{
+		orchestrator: orchestrator,
+	}
+}
+
+// ExecutePlan executes a complete task plan
+func (e *ChainExecutor) ExecutePlan(ctx context.Context, plan *TaskPlan) (*ChainResult, error) {
+	logger.Info("🔗 Starting chain execution for plan: %s", plan.Name)
+
+	e.plan = plan
+	e.state = e.orchestrator.stateManager.CreateState(plan.Description)
+
+	// Initialize state metadata with plan context
+	e.state.Metadata["plan_id"] = plan.ID
+	e.state.Metadata["plan_name"] = plan.Name
+	e.state.Metadata["task_outputs"] = make(map[string]string)
+
+	startTime := time.Now()
+	plan.Status = PlanStatusExecuting
+
+	// Execute tasks based on dependencies
+	executedCount := 0
+	maxIterations := len(plan.Tasks) * 2 // Safety limit
+
+	for !plan.IsComplete() && executedCount < maxIterations {
+		select {
+		case <-ctx.Done():
+			plan.Status = PlanStatusCancelled
+			return e.buildResult(startTime), ctx.Err()
+		default:
+		}
+
+		// Get next ready task
+		nextTask, err := plan.GetNextTask()
+		if err != nil {
+			// No tasks ready, check if we're stuck
+			if plan.HasFailures() {
+				plan.Status = PlanStatusFailed
+				break
+			}
+			// This shouldn't happen with proper dependency management
+			logger.Error("No tasks ready but plan not complete")
+			break
+		}
+
+		logger.Info("📌 Executing task: %s (ID: %s)", nextTask.Name, nextTask.ID)
+
+		// Execute the task
+		if err := e.executeTask(ctx, nextTask); err != nil {
+			logger.Error("Task %s failed: %v", nextTask.ID, err)
+			nextTask.Error = err.Error()
+			plan.UpdateTaskStatus(nextTask.ID, TaskStatusFailed)
+
+			// Decide whether to continue or fail the plan
+			if e.shouldFailPlan(nextTask) {
+				plan.Status = PlanStatusFailed
+				break
+			}
+		}
+
+		executedCount++
+	}
+
+	// Update final plan status
+	plan.updatePlanStatus()
+
+	result := e.buildResult(startTime)
+	logger.Info("🏁 Chain execution completed: status=%s, tasks_executed=%d, duration=%v",
+		plan.Status, executedCount, result.Duration)
+
+	return result, nil
+}
+
+// executeTask executes a single task in the plan
+func (e *ChainExecutor) executeTask(ctx context.Context, task *SubTask) error {
+	// Update task status
+	if err := e.plan.UpdateTaskStatus(task.ID, TaskStatusRunning); err != nil {
+		return err
+	}
+
+	// Prepare input with context from previous tasks
+	input := e.prepareTaskInput(task)
+
+	// Create routing decision for the task
+	decision := &RouteDecision{
+		TargetAgent: task.AgentType,
+		Instruction: input,
+		Parameters:  task.Metadata,
+	}
+
+	// Get the agent
+	agent, err := e.orchestrator.registry.GetAgent(task.AgentType)
+	if err != nil {
+		return fmt.Errorf("agent not found: %s", task.AgentType)
+	}
+
+	// Execute with the agent
+	response, err := agent.Execute(ctx, decision, e.state)
+	if err != nil {
+		return fmt.Errorf("agent execution failed: %w", err)
+	}
+
+	// Update task with results
+	if err := e.plan.UpdateTaskResult(task.ID, response.Response, response.NextAction); err != nil {
+		return err
+	}
+
+	// Store output in state for use by subsequent tasks
+	taskOutputs := e.state.Metadata["task_outputs"].(map[string]string)
+	taskOutputs[task.ID] = response.Response
+
+	// Handle NextAction if provided
+	if response.NextAction != nil {
+		e.handleNextAction(task, response.NextAction)
+	}
+
+	// Update task status based on response
+	if response.Status == "success" {
+		return e.plan.UpdateTaskStatus(task.ID, TaskStatusCompleted)
+	} else {
+		return e.plan.UpdateTaskStatus(task.ID, TaskStatusFailed)
+	}
+}
+
+// prepareTaskInput prepares the input for a task, including context from previous tasks
+func (e *ChainExecutor) prepareTaskInput(task *SubTask) string {
+	input := task.Input
+
+	// Add context from dependencies if available
+	if deps, hasDeps := e.plan.Dependencies[task.ID]; hasDeps {
+		taskOutputs := e.state.Metadata["task_outputs"].(map[string]string)
+
+		contextParts := []string{}
+		for _, depID := range deps {
+			if output, exists := taskOutputs[depID]; exists {
+				depTask, _ := e.plan.GetTask(depID)
+				if depTask != nil {
+					contextParts = append(contextParts,
+						fmt.Sprintf("Previous step (%s) output:\n%s", depTask.Name, output))
+				}
+			}
+		}
+
+		if len(contextParts) > 0 {
+			input = fmt.Sprintf("%s\n\nContext from previous steps:\n%s",
+				input, strings.Join(contextParts, "\n\n"))
+		}
+	}
+
+	return input
+}
+
+// handleNextAction processes a NextAction suggestion from an agent
+func (e *ChainExecutor) handleNextAction(currentTask *SubTask, nextAction *RouteDecision) {
+	logger.Debug("Agent suggested next action: %s", nextAction.TargetAgent)
+
+	// Check if we can map this to an existing task in the plan
+	for i := range e.plan.Tasks {
+		task := &e.plan.Tasks[i]
+		if task.Status == TaskStatusPending && task.AgentType == nextAction.TargetAgent {
+			// Found a matching pending task, update its input if provided
+			if nextAction.Instruction != "" {
+				task.Input = fmt.Sprintf("%s\n\nAdditional context: %s",
+					task.Input, nextAction.Instruction)
+			}
+			logger.Debug("Mapped NextAction to existing task: %s", task.ID)
+			return
+		}
+	}
+
+	// If no matching task exists, we could dynamically add one (future enhancement)
+	logger.Debug("NextAction doesn't match any pending tasks, continuing with plan")
+}
+
+// shouldFailPlan determines if a task failure should fail the entire plan
+func (e *ChainExecutor) shouldFailPlan(task *SubTask) bool {
+	// Check if task is marked as critical
+	if critical, ok := task.Metadata["critical"].(bool); ok && critical {
+		return true
+	}
+
+	// Check if other tasks depend on this one
+	for _, t := range e.plan.Tasks {
+		if deps, hasDeps := e.plan.Dependencies[t.ID]; hasDeps {
+			for _, depID := range deps {
+				if depID == task.ID && t.Status == TaskStatusPending {
+					// A pending task depends on this failed task
+					logger.Warn("Task %s has dependent tasks, failing plan", task.ID)
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// buildResult builds the chain execution result
+func (e *ChainExecutor) buildResult(startTime time.Time) *ChainResult {
+	completedTasks := 0
+	failedTasks := 0
+
+	for _, task := range e.plan.Tasks {
+		switch task.Status {
+		case TaskStatusCompleted:
+			completedTasks++
+		case TaskStatusFailed:
+			failedTasks++
+		}
+	}
+
+	return &ChainResult{
+		PlanID:         e.plan.ID,
+		PlanName:       e.plan.Name,
+		Status:         e.plan.Status,
+		TotalTasks:     len(e.plan.Tasks),
+		CompletedTasks: completedTasks,
+		FailedTasks:    failedTasks,
+		Duration:       time.Since(startTime),
+		TaskResults:    e.plan.Tasks,
+		State:          e.state,
+	}
+}
+
+// ChainResult represents the result of executing a task plan
+type ChainResult struct {
+	PlanID         string        `json:"plan_id"`
+	PlanName       string        `json:"plan_name"`
+	Status         PlanStatus    `json:"status"`
+	TotalTasks     int           `json:"total_tasks"`
+	CompletedTasks int           `json:"completed_tasks"`
+	FailedTasks    int           `json:"failed_tasks"`
+	Duration       time.Duration `json:"duration"`
+	TaskResults    []SubTask     `json:"task_results"`
+	State          *TaskState    `json:"state"`
+}
+
+// ExecuteChain is a convenience method on the Orchestrator to execute a task plan
+func (o *Orchestrator) ExecuteChain(ctx context.Context, plan *TaskPlan) (*ChainResult, error) {
+	executor := NewChainExecutor(o)
+	return executor.ExecutePlan(ctx, plan)
+}

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -1,0 +1,267 @@
+package orchestrator
+
+import (
+	"fmt"
+
+	"github.com/killallgit/ryan/pkg/logger"
+	"github.com/spf13/viper"
+)
+
+// Config represents the orchestrator configuration
+type Config struct {
+	// EnabledAgents specifies which agents are enabled
+	EnabledAgents []string `mapstructure:"enabled_agents"`
+
+	// MaxIterations is the maximum number of feedback loop iterations
+	MaxIterations int `mapstructure:"max_iterations"`
+
+	// ShowRoutingInfo determines if routing decisions are shown in output
+	ShowRoutingInfo bool `mapstructure:"show_routing_info"`
+
+	// AgentConfigs holds agent-specific configurations
+	AgentConfigs map[string]AgentConfig `mapstructure:"agents"`
+
+	// DefaultTimeout for agent operations in seconds
+	DefaultTimeout int `mapstructure:"default_timeout"`
+
+	// RetryAttempts for failed agent operations
+	RetryAttempts int `mapstructure:"retry_attempts"`
+}
+
+// AgentConfig represents configuration for a specific agent
+type AgentConfig struct {
+	// Enabled indicates if this agent is enabled
+	Enabled bool `mapstructure:"enabled"`
+
+	// Priority determines agent selection priority (higher = preferred)
+	Priority int `mapstructure:"priority"`
+
+	// Timeout override for this specific agent (seconds)
+	Timeout int `mapstructure:"timeout"`
+
+	// MaxTokens limit for LLM calls
+	MaxTokens int `mapstructure:"max_tokens"`
+
+	// Temperature for LLM calls
+	Temperature float64 `mapstructure:"temperature"`
+
+	// CustomPrompt override for the agent
+	CustomPrompt string `mapstructure:"custom_prompt"`
+
+	// Capabilities that this agent can handle
+	Capabilities []string `mapstructure:"capabilities"`
+}
+
+// DefaultConfig returns the default orchestrator configuration
+func DefaultConfig() *Config {
+	return &Config{
+		EnabledAgents: []string{
+			"tool_caller",
+			"reasoner",
+			"code_gen",
+			"searcher",
+			"planner",
+		},
+		MaxIterations:   10,
+		ShowRoutingInfo: true,
+		DefaultTimeout:  60,
+		RetryAttempts:   2,
+		AgentConfigs: map[string]AgentConfig{
+			"tool_caller": {
+				Enabled:     true,
+				Priority:    10,
+				Timeout:     30,
+				MaxTokens:   2000,
+				Temperature: 0.2,
+				Capabilities: []string{
+					"bash_commands",
+					"file_operations",
+					"git_operations",
+					"search",
+				},
+			},
+			"reasoner": {
+				Enabled:     true,
+				Priority:    8,
+				Timeout:     45,
+				MaxTokens:   4000,
+				Temperature: 0.7,
+				Capabilities: []string{
+					"analysis",
+					"problem_solving",
+					"logic",
+					"mathematical_reasoning",
+				},
+			},
+			"code_gen": {
+				Enabled:     true,
+				Priority:    9,
+				Timeout:     60,
+				MaxTokens:   8000,
+				Temperature: 0.3,
+				Capabilities: []string{
+					"code_generation",
+					"refactoring",
+					"debugging",
+					"documentation",
+				},
+			},
+			"searcher": {
+				Enabled:     true,
+				Priority:    7,
+				Timeout:     30,
+				MaxTokens:   2000,
+				Temperature: 0.5,
+				Capabilities: []string{
+					"file_search",
+					"code_search",
+					"documentation_search",
+				},
+			},
+			"planner": {
+				Enabled:     true,
+				Priority:    6,
+				Timeout:     45,
+				MaxTokens:   3000,
+				Temperature: 0.6,
+				Capabilities: []string{
+					"task_decomposition",
+					"strategy_planning",
+					"workflow_design",
+				},
+			},
+		},
+	}
+}
+
+// LoadConfig loads orchestrator configuration from viper
+func LoadConfig() (*Config, error) {
+	config := DefaultConfig()
+
+	// Set config prefix for orchestrator settings
+	sub := viper.Sub("orchestrator")
+	if sub == nil {
+		logger.Debug("No orchestrator configuration found, using defaults")
+		return config, nil
+	}
+
+	// Unmarshal configuration
+	if err := sub.Unmarshal(config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal orchestrator config: %w", err)
+	}
+
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid orchestrator configuration: %w", err)
+	}
+
+	logger.Info("Loaded orchestrator configuration: %d agents enabled", len(config.EnabledAgents))
+	return config, nil
+}
+
+// Validate checks if the configuration is valid
+func (c *Config) Validate() error {
+	if c.MaxIterations < 1 {
+		return fmt.Errorf("max_iterations must be at least 1")
+	}
+
+	if c.DefaultTimeout < 1 {
+		return fmt.Errorf("default_timeout must be at least 1 second")
+	}
+
+	if c.RetryAttempts < 0 {
+		return fmt.Errorf("retry_attempts cannot be negative")
+	}
+
+	// Validate agent configs
+	for name, agentConfig := range c.AgentConfigs {
+		if agentConfig.Enabled && agentConfig.Priority < 0 {
+			return fmt.Errorf("agent %s has invalid priority: %d", name, agentConfig.Priority)
+		}
+
+		if agentConfig.Temperature < 0 || agentConfig.Temperature > 2 {
+			return fmt.Errorf("agent %s has invalid temperature: %f (must be 0-2)", name, agentConfig.Temperature)
+		}
+
+		if agentConfig.MaxTokens < 0 {
+			return fmt.Errorf("agent %s has invalid max_tokens: %d", name, agentConfig.MaxTokens)
+		}
+	}
+
+	return nil
+}
+
+// IsAgentEnabled checks if a specific agent type is enabled
+func (c *Config) IsAgentEnabled(agentType string) bool {
+	// Check in enabled agents list
+	for _, enabled := range c.EnabledAgents {
+		if enabled == agentType {
+			// Also check agent-specific config
+			if agentConfig, exists := c.AgentConfigs[agentType]; exists {
+				return agentConfig.Enabled
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// GetAgentConfig returns configuration for a specific agent
+func (c *Config) GetAgentConfig(agentType string) (AgentConfig, bool) {
+	config, exists := c.AgentConfigs[agentType]
+	return config, exists
+}
+
+// GetAgentPriority returns the priority for a specific agent
+func (c *Config) GetAgentPriority(agentType string) int {
+	if config, exists := c.AgentConfigs[agentType]; exists {
+		return config.Priority
+	}
+	return 0
+}
+
+// SelectBestAgent selects the best agent based on capabilities and priority
+func (c *Config) SelectBestAgent(requiredCapabilities []string, availableAgents []string) (string, error) {
+	var bestAgent string
+	bestPriority := -1
+	bestCapabilityMatch := 0
+
+	for _, agentType := range availableAgents {
+		if !c.IsAgentEnabled(agentType) {
+			continue
+		}
+
+		agentConfig, exists := c.GetAgentConfig(agentType)
+		if !exists || !agentConfig.Enabled {
+			continue
+		}
+
+		// Count capability matches
+		capabilityMatch := 0
+		for _, required := range requiredCapabilities {
+			for _, capability := range agentConfig.Capabilities {
+				if capability == required {
+					capabilityMatch++
+					break
+				}
+			}
+		}
+
+		// Select agent with best capability match and highest priority
+		if capabilityMatch > bestCapabilityMatch ||
+			(capabilityMatch == bestCapabilityMatch && agentConfig.Priority > bestPriority) {
+			bestAgent = agentType
+			bestPriority = agentConfig.Priority
+			bestCapabilityMatch = capabilityMatch
+		}
+	}
+
+	if bestAgent == "" {
+		return "", fmt.Errorf("no suitable agent found for capabilities: %v", requiredCapabilities)
+	}
+
+	logger.Debug("Selected agent %s with priority %d and %d capability matches",
+		bestAgent, bestPriority, bestCapabilityMatch)
+
+	return bestAgent, nil
+}

--- a/pkg/orchestrator/config_test.go
+++ b/pkg/orchestrator/config_test.go
@@ -1,0 +1,278 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	assert.NotNil(t, config)
+	assert.Equal(t, 10, config.MaxIterations)
+	assert.True(t, config.ShowRoutingInfo)
+	assert.Equal(t, 60, config.DefaultTimeout)
+	assert.Equal(t, 2, config.RetryAttempts)
+
+	// Check enabled agents
+	assert.Contains(t, config.EnabledAgents, "tool_caller")
+	assert.Contains(t, config.EnabledAgents, "reasoner")
+	assert.Contains(t, config.EnabledAgents, "code_gen")
+
+	// Check agent configs
+	toolCallerConfig, exists := config.AgentConfigs["tool_caller"]
+	assert.True(t, exists)
+	assert.True(t, toolCallerConfig.Enabled)
+	assert.Equal(t, 10, toolCallerConfig.Priority)
+	assert.Equal(t, 0.2, toolCallerConfig.Temperature)
+}
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *Config
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				MaxIterations:  5,
+				DefaultTimeout: 30,
+				RetryAttempts:  1,
+				AgentConfigs:   map[string]AgentConfig{},
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid max iterations",
+			config: &Config{
+				MaxIterations:  0,
+				DefaultTimeout: 30,
+				RetryAttempts:  1,
+			},
+			wantError: true,
+			errorMsg:  "max_iterations must be at least 1",
+		},
+		{
+			name: "invalid timeout",
+			config: &Config{
+				MaxIterations:  5,
+				DefaultTimeout: 0,
+				RetryAttempts:  1,
+			},
+			wantError: true,
+			errorMsg:  "default_timeout must be at least 1 second",
+		},
+		{
+			name: "negative retry attempts",
+			config: &Config{
+				MaxIterations:  5,
+				DefaultTimeout: 30,
+				RetryAttempts:  -1,
+			},
+			wantError: true,
+			errorMsg:  "retry_attempts cannot be negative",
+		},
+		{
+			name: "invalid agent priority",
+			config: &Config{
+				MaxIterations:  5,
+				DefaultTimeout: 30,
+				RetryAttempts:  1,
+				AgentConfigs: map[string]AgentConfig{
+					"test_agent": {
+						Enabled:  true,
+						Priority: -1,
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "agent test_agent has invalid priority",
+		},
+		{
+			name: "invalid temperature",
+			config: &Config{
+				MaxIterations:  5,
+				DefaultTimeout: 30,
+				RetryAttempts:  1,
+				AgentConfigs: map[string]AgentConfig{
+					"test_agent": {
+						Enabled:     true,
+						Priority:    5,
+						Temperature: 3.0,
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "agent test_agent has invalid temperature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsAgentEnabled(t *testing.T) {
+	config := &Config{
+		EnabledAgents: []string{"tool_caller", "reasoner"},
+		AgentConfigs: map[string]AgentConfig{
+			"tool_caller": {Enabled: true},
+			"reasoner":    {Enabled: false}, // Disabled in agent config
+			"code_gen":    {Enabled: true},  // Not in enabled list
+		},
+	}
+
+	assert.True(t, config.IsAgentEnabled("tool_caller"))
+	assert.False(t, config.IsAgentEnabled("reasoner")) // Disabled in agent config
+	assert.False(t, config.IsAgentEnabled("code_gen")) // Not in enabled list
+	assert.False(t, config.IsAgentEnabled("unknown"))
+}
+
+func TestGetAgentConfig(t *testing.T) {
+	config := &Config{
+		AgentConfigs: map[string]AgentConfig{
+			"tool_caller": {
+				Enabled:     true,
+				Priority:    10,
+				Temperature: 0.5,
+			},
+		},
+	}
+
+	// Existing agent
+	agentConfig, exists := config.GetAgentConfig("tool_caller")
+	assert.True(t, exists)
+	assert.Equal(t, 10, agentConfig.Priority)
+	assert.Equal(t, 0.5, agentConfig.Temperature)
+
+	// Non-existing agent
+	_, exists = config.GetAgentConfig("unknown")
+	assert.False(t, exists)
+}
+
+func TestGetAgentPriority(t *testing.T) {
+	config := &Config{
+		AgentConfigs: map[string]AgentConfig{
+			"tool_caller": {Priority: 10},
+			"reasoner":    {Priority: 5},
+		},
+	}
+
+	assert.Equal(t, 10, config.GetAgentPriority("tool_caller"))
+	assert.Equal(t, 5, config.GetAgentPriority("reasoner"))
+	assert.Equal(t, 0, config.GetAgentPriority("unknown"))
+}
+
+func TestSelectBestAgent(t *testing.T) {
+	config := &Config{
+		EnabledAgents: []string{"tool_caller", "reasoner", "searcher"},
+		AgentConfigs: map[string]AgentConfig{
+			"tool_caller": {
+				Enabled:      true,
+				Priority:     10,
+				Capabilities: []string{"bash_commands", "file_operations"},
+			},
+			"reasoner": {
+				Enabled:      true,
+				Priority:     8,
+				Capabilities: []string{"analysis", "problem_solving"},
+			},
+			"searcher": {
+				Enabled:      true,
+				Priority:     6,
+				Capabilities: []string{"file_search", "code_search"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		requiredCapabilities []string
+		availableAgents      []string
+		expectedAgent        string
+		expectError          bool
+	}{
+		{
+			name:                 "select by capability match",
+			requiredCapabilities: []string{"bash_commands"},
+			availableAgents:      []string{"tool_caller", "reasoner"},
+			expectedAgent:        "tool_caller",
+			expectError:          false,
+		},
+		{
+			name:                 "select by priority when equal match",
+			requiredCapabilities: []string{"general"},
+			availableAgents:      []string{"tool_caller", "reasoner"},
+			expectedAgent:        "tool_caller", // Higher priority
+			expectError:          false,
+		},
+		{
+			name:                 "select searcher for search capability",
+			requiredCapabilities: []string{"file_search"},
+			availableAgents:      []string{"tool_caller", "reasoner", "searcher"},
+			expectedAgent:        "searcher",
+			expectError:          false,
+		},
+		{
+			name:                 "no available agents",
+			requiredCapabilities: []string{"unknown_capability"},
+			availableAgents:      []string{},
+			expectedAgent:        "",
+			expectError:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent, err := config.SelectBestAgent(tt.requiredCapabilities, tt.availableAgents)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedAgent, agent)
+			}
+		})
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	// Test with no config
+	viper.Reset()
+	config, err := LoadConfig()
+	require.NoError(t, err)
+	assert.NotNil(t, config)
+	assert.Equal(t, DefaultConfig(), config)
+
+	// Test with partial config
+	viper.Reset()
+	viper.Set("orchestrator.max_iterations", 20)
+	viper.Set("orchestrator.show_routing_info", false)
+
+	config, err = LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, 20, config.MaxIterations)
+	assert.False(t, config.ShowRoutingInfo)
+
+	// Test with invalid config
+	viper.Reset()
+	viper.Set("orchestrator.max_iterations", -1)
+
+	config, err = LoadConfig()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid orchestrator configuration")
+}

--- a/pkg/orchestrator/feedback.go
+++ b/pkg/orchestrator/feedback.go
@@ -60,7 +60,10 @@ func (fl *FeedbackLoop) Run(ctx context.Context, state *TaskState) (*TaskResult,
 			return fl.buildResult(state, startTime), nil
 		}
 
-		logger.Info("🎯 Next action: execute with %s agent", decision.TargetAgent)
+		// Visual feedback for agent switching
+		agentName := string(decision.TargetAgent)
+		logger.Info("🎯 Next action: execute with %s agent", agentName)
+		fmt.Printf("[%s]\n", agentName)
 
 		// Execute with selected agent
 		state.CurrentPhase = PhaseExecution

--- a/pkg/orchestrator/history.go
+++ b/pkg/orchestrator/history.go
@@ -1,0 +1,112 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/killallgit/ryan/pkg/logger"
+	"github.com/killallgit/ryan/pkg/memory"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// HistoryManager manages the orchestrator's conversation history
+type HistoryManager struct {
+	memory *memory.Memory
+}
+
+// NewHistoryManager creates a new history manager
+func NewHistoryManager(sessionID string) (*HistoryManager, error) {
+	mem, err := memory.New(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create memory: %w", err)
+	}
+
+	return &HistoryManager{memory: mem}, nil
+}
+
+// SaveTaskExecution saves a complete task execution to history
+func (h *HistoryManager) SaveTaskExecution(result *TaskResult) error {
+	logger.Debug("💾 Saving orchestrator task execution to history")
+
+	// Create a structured summary of the orchestrator execution
+	summary := createExecutionSummary(result)
+
+	// Save the user query
+	if err := h.memory.AddUserMessage(result.Query); err != nil {
+		return fmt.Errorf("failed to save user query: %w", err)
+	}
+
+	// Save the orchestrator response with detailed breakdown
+	if err := h.memory.AddAssistantMessage(summary); err != nil {
+		return fmt.Errorf("failed to save orchestrator response: %w", err)
+	}
+
+	// Optionally save the full detailed history as metadata
+	// Note: We'll skip system messages for now as the interface doesn't support them directly
+	fullHistoryJSON, err := json.Marshal(result)
+	if err != nil {
+		logger.Warn("Could not serialize full task result for history: %v", err)
+	} else {
+		logger.Debug("Full task result serialized: %d bytes", len(fullHistoryJSON))
+		// Could be saved to a separate debug file if needed
+	}
+
+	logger.Info("✅ Task execution saved to history: %d agent interactions", len(result.History))
+	return nil
+}
+
+// createExecutionSummary creates a human-readable summary of the orchestrator execution
+func createExecutionSummary(result *TaskResult) string {
+	summary := fmt.Sprintf("🤖 **Orchestrator Execution Summary**\n\n")
+	summary += fmt.Sprintf("**Query:** %s\n", result.Query)
+	summary += fmt.Sprintf("**Status:** %s\n", result.Status)
+	summary += fmt.Sprintf("**Duration:** %v\n", result.Duration)
+	summary += fmt.Sprintf("**Agents Used:** %d\n\n", len(result.History))
+
+	if len(result.History) > 0 {
+		summary += "**Execution Flow:**\n"
+		for i, response := range result.History {
+			summary += fmt.Sprintf("%d. **%s** (%s)", i+1, response.AgentType, response.Status)
+
+			// Add tool usage info
+			if len(response.ToolsCalled) > 0 {
+				toolNames := make([]string, len(response.ToolsCalled))
+				for j, tool := range response.ToolsCalled {
+					toolNames[j] = tool.Name
+				}
+				summary += fmt.Sprintf(" - Used tools: %v", toolNames)
+			}
+			summary += "\n"
+
+			// Add error info if present
+			if response.Error != nil {
+				summary += fmt.Sprintf("   Error: %s\n", *response.Error)
+			}
+		}
+		summary += "\n"
+	}
+
+	// Add final result
+	summary += "**Final Result:**\n"
+	summary += result.Result
+
+	return summary
+}
+
+// GetConversationHistory returns the conversation history
+func (h *HistoryManager) GetConversationHistory() ([]llms.ChatMessage, error) {
+	return h.memory.GetMessages()
+}
+
+// Clear clears the conversation history
+func (h *HistoryManager) Clear() error {
+	return h.memory.Clear()
+}
+
+// Close closes the history manager
+func (h *HistoryManager) Close() error {
+	if h.memory != nil {
+		return h.memory.Close()
+	}
+	return nil
+}

--- a/pkg/orchestrator/intent_test.go
+++ b/pkg/orchestrator/intent_test.go
@@ -1,0 +1,309 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// MockLLM for testing intent analysis
+type MockIntentLLM struct {
+	responses map[string]string
+}
+
+func (m *MockIntentLLM) Call(ctx context.Context, prompt string, options ...llms.CallOption) (string, error) {
+	// Return predefined responses based on the query in the prompt
+	for key, response := range m.responses {
+		if contains(prompt, key) {
+			return response, nil
+		}
+	}
+	// Default response
+	return `{"type": "reasoning", "confidence": 0.5, "required_capabilities": ["general"], "reasoning": "default"}`, nil
+}
+
+func (m *MockIntentLLM) Generate(ctx context.Context, prompts []string, options ...llms.CallOption) ([]string, error) {
+	results := make([]string, len(prompts))
+	for i, prompt := range prompts {
+		result, _ := m.Call(ctx, prompt, options...)
+		results[i] = result
+	}
+	return results, nil
+}
+
+func (m *MockIntentLLM) CreateEmbedding(ctx context.Context, inputTexts []string) ([][]float32, error) {
+	return nil, nil
+}
+
+func (m *MockIntentLLM) GenerateContent(ctx context.Context, messages []llms.MessageContent, options ...llms.CallOption) (*llms.ContentResponse, error) {
+	// For testing, just use the last message
+	if len(messages) > 0 {
+		lastMsg := messages[len(messages)-1]
+		for _, part := range lastMsg.Parts {
+			if textPart, ok := part.(llms.TextContent); ok {
+				response, err := m.Call(ctx, textPart.Text, options...)
+				if err != nil {
+					return nil, err
+				}
+				return &llms.ContentResponse{
+					Choices: []*llms.ContentChoice{
+						{
+							Content: response,
+						},
+					},
+				}, nil
+			}
+		}
+	}
+	return &llms.ContentResponse{}, nil
+}
+
+func contains(text, substr string) bool {
+	return len(text) >= len(substr) && text[len(text)-len(substr):] == substr ||
+		len(text) >= len(substr) && containsSubstring(text, substr)
+}
+
+func containsSubstring(text, substr string) bool {
+	for i := 0; i <= len(text)-len(substr); i++ {
+		if text[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAnalyzeIntent_FileOperations(t *testing.T) {
+	tests := []struct {
+		name               string
+		query              string
+		llmResponse        string
+		expectedType       string
+		expectedConfidence float64
+		shouldContainCap   string
+	}{
+		{
+			name:  "Read file request",
+			query: "read a random file",
+			llmResponse: `{
+				"type": "tool_use",
+				"confidence": 0.9,
+				"required_capabilities": ["file_read", "bash"],
+				"reasoning": "User wants to read a file which requires file system tools"
+			}`,
+			expectedType:       "tool_use",
+			expectedConfidence: 0.9,
+			shouldContainCap:   "file_read",
+		},
+		{
+			name:  "List files request",
+			query: "list all files in the current directory",
+			llmResponse: `{
+				"type": "tool_use",
+				"confidence": 0.95,
+				"required_capabilities": ["bash", "list", "filesystem"],
+				"reasoning": "User wants to list files which requires bash command"
+			}`,
+			expectedType:       "tool_use",
+			expectedConfidence: 0.95,
+			shouldContainCap:   "bash",
+		},
+		{
+			name:  "Check directory contents",
+			query: "check what's in the src folder",
+			llmResponse: `{
+				"type": "tool_use",
+				"confidence": 0.85,
+				"required_capabilities": ["bash", "directory", "ls"],
+				"reasoning": "User wants to check directory contents"
+			}`,
+			expectedType:       "tool_use",
+			expectedConfidence: 0.85,
+			shouldContainCap:   "directory",
+		},
+		{
+			name:  "Write file request",
+			query: "create a new file called test.txt",
+			llmResponse: `{
+				"type": "tool_use",
+				"confidence": 0.9,
+				"required_capabilities": ["file_write", "create"],
+				"reasoning": "User wants to create a file which requires file_write tool"
+			}`,
+			expectedType:       "tool_use",
+			expectedConfidence: 0.9,
+			shouldContainCap:   "file_write",
+		},
+		{
+			name:  "Run command request",
+			query: "run npm install",
+			llmResponse: `{
+				"type": "tool_use",
+				"confidence": 0.95,
+				"required_capabilities": ["bash", "command", "npm"],
+				"reasoning": "User wants to execute a bash command"
+			}`,
+			expectedType:       "tool_use",
+			expectedConfidence: 0.95,
+			shouldContainCap:   "bash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock LLM with response
+			mockLLM := &MockIntentLLM{
+				responses: map[string]string{
+					tt.query: tt.llmResponse,
+				},
+			}
+
+			// Create orchestrator with mock LLM
+			orch := &Orchestrator{
+				llm:           mockLLM,
+				config:        DefaultConfig(),
+				maxIterations: 5,
+			}
+
+			// Test intent analysis
+			ctx := context.Background()
+			intent, err := orch.AnalyzeIntent(ctx, tt.query)
+			require.NoError(t, err)
+
+			// Verify results
+			assert.Equal(t, tt.expectedType, intent.Type, "Intent type should match")
+			assert.Equal(t, tt.expectedConfidence, intent.Confidence, "Confidence should match")
+
+			// Check for required capability
+			hasCapability := false
+			for _, cap := range intent.RequiredCapabilities {
+				if cap == tt.shouldContainCap {
+					hasCapability = true
+					break
+				}
+			}
+			assert.True(t, hasCapability, "Should contain capability: %s", tt.shouldContainCap)
+		})
+	}
+}
+
+func TestSelectAgentForIntent_FileOperations(t *testing.T) {
+	tests := []struct {
+		name          string
+		intent        *TaskIntent
+		expectedAgent AgentType
+	}{
+		{
+			name: "High confidence tool_use",
+			intent: &TaskIntent{
+				Type:                 "tool_use",
+				Confidence:           0.9,
+				RequiredCapabilities: []string{"file_read", "bash"},
+			},
+			expectedAgent: AgentToolCaller,
+		},
+		{
+			name: "Low confidence with file keyword",
+			intent: &TaskIntent{
+				Type:                 "reasoning",
+				Confidence:           0.5,
+				RequiredCapabilities: []string{"file", "read"},
+			},
+			expectedAgent: AgentToolCaller,
+		},
+		{
+			name: "Reasoning with filesystem capability",
+			intent: &TaskIntent{
+				Type:                 "reasoning",
+				Confidence:           0.8,
+				RequiredCapabilities: []string{"filesystem", "analysis"},
+			},
+			expectedAgent: AgentToolCaller,
+		},
+		{
+			name: "Pure reasoning without tool keywords",
+			intent: &TaskIntent{
+				Type:                 "reasoning",
+				Confidence:           0.9,
+				RequiredCapabilities: []string{"analysis", "explanation"},
+			},
+			expectedAgent: AgentReasoner,
+		},
+		{
+			name: "Search intent",
+			intent: &TaskIntent{
+				Type:                 "search",
+				Confidence:           0.85,
+				RequiredCapabilities: []string{"code_search", "pattern_matching"},
+			},
+			expectedAgent: AgentSearcher,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create orchestrator
+			orch := &Orchestrator{
+				config: DefaultConfig(),
+			}
+
+			// Test agent selection
+			selectedAgent := orch.selectAgentForIntent(tt.intent)
+			assert.Equal(t, tt.expectedAgent, selectedAgent, "Selected agent should match expected")
+		})
+	}
+}
+
+func TestShouldUseToolCallerForCapabilities(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilities []string
+		expected     bool
+	}{
+		{
+			name:         "File operations",
+			capabilities: []string{"file_read", "bash"},
+			expected:     true,
+		},
+		{
+			name:         "Directory operations",
+			capabilities: []string{"directory", "listing"},
+			expected:     true,
+		},
+		{
+			name:         "System commands",
+			capabilities: []string{"command", "execute"},
+			expected:     true,
+		},
+		{
+			name:         "Git operations",
+			capabilities: []string{"git", "version_control"},
+			expected:     true,
+		},
+		{
+			name:         "Web operations",
+			capabilities: []string{"web", "fetch"},
+			expected:     true,
+		},
+		{
+			name:         "Pure reasoning",
+			capabilities: []string{"analysis", "explanation", "understanding"},
+			expected:     false,
+		},
+		{
+			name:         "Code generation",
+			capabilities: []string{"implementation", "algorithm", "function"},
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orch := &Orchestrator{}
+			result := orch.shouldUseToolCallerForCapabilities(tt.capabilities)
+			assert.Equal(t, tt.expected, result, "Tool caller detection should match expected")
+		})
+	}
+}

--- a/pkg/orchestrator/streaming.go
+++ b/pkg/orchestrator/streaming.go
@@ -1,0 +1,268 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/killallgit/ryan/pkg/logger"
+	"github.com/killallgit/ryan/pkg/stream"
+)
+
+// StreamingHandler wraps a stream.Handler to intercept and format orchestrator output
+type StreamingHandler struct {
+	inner        stream.Handler
+	showRouting  bool
+	currentAgent string
+	buffer       strings.Builder
+}
+
+// NewStreamingHandler creates a new streaming handler for orchestrator
+func NewStreamingHandler(handler stream.Handler, showRouting bool) *StreamingHandler {
+	return &StreamingHandler{
+		inner:       handler,
+		showRouting: showRouting,
+	}
+}
+
+// OnChunk handles streaming chunks from agents
+func (h *StreamingHandler) OnChunk(chunk []byte) error {
+	// Buffer the chunk
+	h.buffer.Write(chunk)
+
+	// Pass through to inner handler
+	return h.inner.OnChunk(chunk)
+}
+
+// OnComplete handles completion of streaming
+func (h *StreamingHandler) OnComplete(finalContent string) error {
+	return h.inner.OnComplete(finalContent)
+}
+
+// OnError handles streaming errors
+func (h *StreamingHandler) OnError(err error) {
+	h.inner.OnError(err)
+}
+
+// OnRoutingDecision sends routing information to the stream
+func (h *StreamingHandler) OnRoutingDecision(decision *RouteDecision) error {
+	if !h.showRouting {
+		return nil
+	}
+
+	h.currentAgent = string(decision.TargetAgent)
+
+	// Format routing info as markdown
+	routingInfo := fmt.Sprintf("\n🎯 **Routing to %s agent**\n", decision.TargetAgent)
+	// Add instruction if available
+	if decision.Instruction != "" {
+		routingInfo += fmt.Sprintf("*Task: %s*\n\n", decision.Instruction)
+	}
+
+	return h.inner.OnChunk([]byte(routingInfo))
+}
+
+// OnAgentStart notifies when an agent starts processing
+func (h *StreamingHandler) OnAgentStart(agentType AgentType) error {
+	if !h.showRouting {
+		return nil
+	}
+
+	info := fmt.Sprintf("\n⚙️ **%s agent processing...**\n", agentType)
+	return h.inner.OnChunk([]byte(info))
+}
+
+// OnAgentComplete notifies when an agent completes
+func (h *StreamingHandler) OnAgentComplete(agentType AgentType, status string) error {
+	if !h.showRouting {
+		return nil
+	}
+
+	emoji := "✅"
+	if status == "failed" {
+		emoji = "❌"
+	}
+
+	info := fmt.Sprintf("\n%s **%s agent %s**\n\n", emoji, agentType, status)
+	return h.inner.OnChunk([]byte(info))
+}
+
+// ExecuteStream executes a task with streaming output
+func (o *Orchestrator) ExecuteStream(ctx context.Context, query string, handler stream.Handler) (*TaskResult, error) {
+	logger.Debug("🎯 Orchestrator executing with streaming: %s", query)
+
+	// Wrap the handler to intercept orchestrator events
+	streamHandler := NewStreamingHandler(handler, true)
+
+	// Create initial task state
+	state := o.stateManager.CreateState(query)
+
+	// Stream initial status
+	initialMsg := fmt.Sprintf("🤖 **Orchestrator Processing**: %s\n\n", query)
+	if err := handler.OnChunk([]byte(initialMsg)); err != nil {
+		return nil, err
+	}
+
+	// Analyze intent
+	intentMsg := "🧠 **Analyzing task intent...**\n"
+	if err := handler.OnChunk([]byte(intentMsg)); err != nil {
+		return nil, err
+	}
+
+	intent, err := o.AnalyzeIntent(ctx, query)
+	if err != nil {
+		handler.OnError(fmt.Errorf("failed to analyze intent: %w", err))
+		return nil, err
+	}
+	state.Intent = intent
+
+	// Stream intent result
+	intentResult := fmt.Sprintf("📊 **Intent**: %s (confidence: %.2f)\n", intent.Type, intent.Confidence)
+	if err := handler.OnChunk([]byte(intentResult)); err != nil {
+		return nil, err
+	}
+
+	// Execute with streaming feedback loop
+	result, err := o.streamingFeedbackLoop(ctx, state, streamHandler)
+	if err != nil {
+		handler.OnError(err)
+		return nil, err
+	}
+
+	// Stream final summary
+	summary := o.formatStreamingSummary(result)
+	if err := handler.OnChunk([]byte(summary)); err != nil {
+		return nil, err
+	}
+
+	// Complete the stream
+	if err := handler.OnComplete(result.Result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// streamingFeedbackLoop runs the feedback loop with streaming support
+func (o *Orchestrator) streamingFeedbackLoop(ctx context.Context, state *TaskState, handler *StreamingHandler) (*TaskResult, error) {
+	startTime := time.Now()
+
+	// Initialize state
+	state.CurrentPhase = PhaseRouting
+	state.Status = StatusInProgress
+
+	for i := 0; i < o.maxIterations; i++ {
+		// Check context cancellation
+		select {
+		case <-ctx.Done():
+			state.Status = StatusCancelled
+			return o.buildStreamingResult(state, startTime), ctx.Err()
+		default:
+		}
+
+		// Route to agent
+		decision, err := o.Route(ctx, state.Intent, state)
+		if err != nil {
+			state.Status = StatusFailed
+			return o.buildStreamingResult(state, startTime), err
+		}
+
+		if decision == nil {
+			state.Status = StatusCompleted
+			state.CurrentPhase = PhaseComplete
+			return o.buildStreamingResult(state, startTime), nil
+		}
+
+		// Notify about routing decision
+		if err := handler.OnRoutingDecision(decision); err != nil {
+			return nil, err
+		}
+
+		// Get the agent from registry
+		agent, err := o.registry.GetAgent(decision.TargetAgent)
+		if err != nil {
+			return nil, fmt.Errorf("agent not found: %s", decision.TargetAgent)
+		}
+
+		// Notify agent start
+		if err := handler.OnAgentStart(decision.TargetAgent); err != nil {
+			return nil, err
+		}
+
+		// Execute agent (agents should support streaming internally)
+		state.CurrentPhase = PhaseExecution
+		response, err := agent.Execute(ctx, decision, state)
+		if err != nil {
+			handler.OnError(err)
+			return nil, err
+		}
+
+		// Notify agent completion
+		if err := handler.OnAgentComplete(decision.TargetAgent, response.Status); err != nil {
+			return nil, err
+		}
+
+		// Update state
+		state.History = append(state.History, *response)
+
+		// Process feedback
+		state.CurrentPhase = PhaseFeedback
+		nextStep, err := o.ProcessFeedback(ctx, response, state)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if complete
+		if nextStep.Action == ActionComplete {
+			state.Status = StatusCompleted
+			state.CurrentPhase = PhaseComplete
+			return o.buildStreamingResult(state, startTime), nil
+		}
+
+		// Continue with next iteration if needed
+		if nextStep.Action == ActionRetry || nextStep.Action == ActionContinue {
+			continue
+		}
+	}
+
+	// Max iterations reached
+	state.Status = StatusFailed
+	return o.buildStreamingResult(state, startTime), fmt.Errorf("max iterations reached")
+}
+
+// buildStreamingResult builds the final result from state
+func (o *Orchestrator) buildStreamingResult(state *TaskState, startTime time.Time) *TaskResult {
+	// Collect all agent responses
+	var resultBuilder strings.Builder
+	for _, resp := range state.History {
+		if resp.Response != "" {
+			resultBuilder.WriteString(resp.Response)
+			resultBuilder.WriteString("\n")
+		}
+	}
+
+	return &TaskResult{
+		ID:        state.ID,
+		Query:     state.Query,
+		Result:    strings.TrimSpace(resultBuilder.String()),
+		Status:    state.Status,
+		History:   state.History,
+		Duration:  time.Since(startTime),
+		StartTime: startTime,
+		EndTime:   time.Now(),
+	}
+}
+
+// formatStreamingSummary formats a summary for the streaming output
+func (o *Orchestrator) formatStreamingSummary(result *TaskResult) string {
+	var sb strings.Builder
+
+	sb.WriteString("\n---\n")
+	sb.WriteString("📋 **Execution Summary**\n")
+	sb.WriteString(fmt.Sprintf("⏱️ Duration: %v\n", result.Duration))
+	sb.WriteString(fmt.Sprintf("🔄 Agent interactions: %d\n", len(result.History)))
+	sb.WriteString(fmt.Sprintf("✅ Status: %s\n", result.Status))
+
+	return sb.String()
+}

--- a/pkg/orchestrator/streaming_test.go
+++ b/pkg/orchestrator/streaming_test.go
@@ -100,20 +100,16 @@ func TestStreamingHandler(t *testing.T) {
 		// Test agent start
 		err := streamHandler.OnAgentStart(AgentToolCaller)
 		assert.NoError(t, err)
-		assert.Contains(t, mockHandler.GetFullContent(), "tool_caller agent processing")
+		assert.Contains(t, mockHandler.GetFullContent(), "[tool_caller]")
 
-		// Test agent complete - success
+		// Test agent complete - success (no output expected now)
 		err = streamHandler.OnAgentComplete(AgentToolCaller, "success")
 		assert.NoError(t, err)
-		assert.Contains(t, mockHandler.GetFullContent(), "✅")
-		assert.Contains(t, mockHandler.GetFullContent(), "tool_caller agent success")
 
-		// Test agent complete - failure
+		// Test agent complete - failure (no output expected now)
 		mockHandler.chunks = []string{} // Reset
 		err = streamHandler.OnAgentComplete(AgentReasoner, "failed")
 		assert.NoError(t, err)
-		assert.Contains(t, mockHandler.GetFullContent(), "❌")
-		assert.Contains(t, mockHandler.GetFullContent(), "reasoner agent failed")
 	})
 }
 
@@ -148,10 +144,9 @@ func TestOrchestratorExecuteStream(t *testing.T) {
 
 		// Check that streaming output was generated
 		fullContent := mockHandler.GetFullContent()
-		assert.Contains(t, fullContent, "Orchestrator Processing")
-		assert.Contains(t, fullContent, "Analyzing task intent")
-		assert.Contains(t, fullContent, "Intent**: reasoning") // Format includes **
-		assert.Contains(t, fullContent, "Execution Summary")
+		// We removed the verbose messages, so just check for agent output
+		assert.Contains(t, fullContent, "[reasoner]")
+		assert.Contains(t, fullContent, "Mock agent response")
 	})
 
 	t.Run("streaming with agent failure", func(t *testing.T) {

--- a/pkg/orchestrator/streaming_test.go
+++ b/pkg/orchestrator/streaming_test.go
@@ -1,0 +1,275 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockStreamHandler for testing streaming
+type MockStreamHandler struct {
+	chunks       []string
+	finalContent string
+	errors       []error
+}
+
+func NewMockStreamHandler() *MockStreamHandler {
+	return &MockStreamHandler{
+		chunks: []string{},
+		errors: []error{},
+	}
+}
+
+func (h *MockStreamHandler) OnChunk(chunk []byte) error {
+	h.chunks = append(h.chunks, string(chunk))
+	return nil
+}
+
+func (h *MockStreamHandler) OnComplete(finalContent string) error {
+	h.finalContent = finalContent
+	return nil
+}
+
+func (h *MockStreamHandler) OnError(err error) {
+	h.errors = append(h.errors, err)
+}
+
+func (h *MockStreamHandler) GetFullContent() string {
+	return strings.Join(h.chunks, "")
+}
+
+func TestStreamingHandler(t *testing.T) {
+	t.Run("basic streaming", func(t *testing.T) {
+		mockHandler := NewMockStreamHandler()
+		streamHandler := NewStreamingHandler(mockHandler, true)
+
+		// Test OnChunk
+		err := streamHandler.OnChunk([]byte("Hello "))
+		assert.NoError(t, err)
+		err = streamHandler.OnChunk([]byte("World"))
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, len(mockHandler.chunks))
+		assert.Equal(t, "Hello World", mockHandler.GetFullContent())
+
+		// Test OnComplete
+		err = streamHandler.OnComplete("Final content")
+		assert.NoError(t, err)
+		assert.Equal(t, "Final content", mockHandler.finalContent)
+
+		// Test OnError
+		streamHandler.OnError(assert.AnError)
+		assert.Equal(t, 1, len(mockHandler.errors))
+	})
+
+	t.Run("routing decision display", func(t *testing.T) {
+		mockHandler := NewMockStreamHandler()
+		streamHandler := NewStreamingHandler(mockHandler, true)
+
+		decision := &RouteDecision{
+			TargetAgent: AgentReasoner,
+			Instruction: "Test task",
+		}
+
+		err := streamHandler.OnRoutingDecision(decision)
+		assert.NoError(t, err)
+		assert.Contains(t, mockHandler.GetFullContent(), "Routing to reasoner agent")
+		assert.Contains(t, mockHandler.GetFullContent(), "Test task")
+	})
+
+	t.Run("routing info disabled", func(t *testing.T) {
+		mockHandler := NewMockStreamHandler()
+		streamHandler := NewStreamingHandler(mockHandler, false) // Routing disabled
+
+		decision := &RouteDecision{
+			TargetAgent: AgentReasoner,
+		}
+
+		err := streamHandler.OnRoutingDecision(decision)
+		assert.NoError(t, err)
+		assert.Empty(t, mockHandler.chunks) // No output when disabled
+	})
+
+	t.Run("agent status notifications", func(t *testing.T) {
+		mockHandler := NewMockStreamHandler()
+		streamHandler := NewStreamingHandler(mockHandler, true)
+
+		// Test agent start
+		err := streamHandler.OnAgentStart(AgentToolCaller)
+		assert.NoError(t, err)
+		assert.Contains(t, mockHandler.GetFullContent(), "tool_caller agent processing")
+
+		// Test agent complete - success
+		err = streamHandler.OnAgentComplete(AgentToolCaller, "success")
+		assert.NoError(t, err)
+		assert.Contains(t, mockHandler.GetFullContent(), "✅")
+		assert.Contains(t, mockHandler.GetFullContent(), "tool_caller agent success")
+
+		// Test agent complete - failure
+		mockHandler.chunks = []string{} // Reset
+		err = streamHandler.OnAgentComplete(AgentReasoner, "failed")
+		assert.NoError(t, err)
+		assert.Contains(t, mockHandler.GetFullContent(), "❌")
+		assert.Contains(t, mockHandler.GetFullContent(), "reasoner agent failed")
+	})
+}
+
+func TestOrchestratorExecuteStream(t *testing.T) {
+	t.Run("basic streaming execution", func(t *testing.T) {
+		// Create mock LLM with intent response
+		mockLLM := NewSimpleMockLLM()
+		mockLLM.WithIntentResponse(&TaskIntent{
+			Type:       "reasoning",
+			Confidence: 0.9,
+		})
+
+		// Create orchestrator
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		// Register a mock agent
+		mockAgent := NewSimpleMockAgent(AgentReasoner)
+		err = orch.RegisterAgent(AgentReasoner, mockAgent)
+		require.NoError(t, err)
+
+		// Create mock handler
+		mockHandler := NewMockStreamHandler()
+
+		// Execute with streaming
+		ctx := context.Background()
+		result, err := orch.ExecuteStream(ctx, "Test query", mockHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, StatusCompleted, result.Status)
+
+		// Check that streaming output was generated
+		fullContent := mockHandler.GetFullContent()
+		assert.Contains(t, fullContent, "Orchestrator Processing")
+		assert.Contains(t, fullContent, "Analyzing task intent")
+		assert.Contains(t, fullContent, "Intent**: reasoning") // Format includes **
+		assert.Contains(t, fullContent, "Execution Summary")
+	})
+
+	t.Run("streaming with agent failure", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		mockLLM.WithIntentResponse(&TaskIntent{
+			Type:       "tool_use",
+			Confidence: 0.8,
+		})
+
+		orch, err := New(mockLLM, WithMaxIterations(2))
+		require.NoError(t, err)
+
+		// Register a failing mock agent
+		mockAgent := &SimpleMockAgent{
+			agentType: AgentToolCaller,
+			responses: []AgentResponse{
+				{
+					AgentType: AgentToolCaller,
+					Status:    "failed",
+					Error:     stringPtr("Mock failure"),
+				},
+			},
+		}
+		err = orch.RegisterAgent(AgentToolCaller, mockAgent)
+		require.NoError(t, err)
+
+		mockHandler := NewMockStreamHandler()
+		ctx := context.Background()
+
+		result, err := orch.ExecuteStream(ctx, "Test with failure", mockHandler)
+
+		// Should still return result even with failure
+		assert.NotNil(t, result)
+
+		// Check streaming output shows failure
+		fullContent := mockHandler.GetFullContent()
+		assert.Contains(t, fullContent, "tool_caller")
+	})
+}
+
+func TestStreamingFeedbackLoop(t *testing.T) {
+	t.Run("successful completion", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		// Register successful agent
+		mockAgent := NewSimpleMockAgent(AgentReasoner)
+		err = orch.RegisterAgent(AgentReasoner, mockAgent)
+		require.NoError(t, err)
+
+		mockHandler := NewMockStreamHandler()
+		streamHandler := NewStreamingHandler(mockHandler, true)
+
+		state := &TaskState{
+			ID:     "test-123",
+			Query:  "Test query",
+			Intent: &TaskIntent{Type: "reasoning", Confidence: 0.9},
+			Status: StatusInProgress,
+		}
+
+		ctx := context.Background()
+		result, err := orch.streamingFeedbackLoop(ctx, state, streamHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, StatusCompleted, state.Status)
+		assert.Equal(t, "test-123", result.ID)
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		mockLLM := NewSimpleMockLLM()
+		orch, err := New(mockLLM)
+		require.NoError(t, err)
+
+		mockHandler := NewMockStreamHandler()
+		streamHandler := NewStreamingHandler(mockHandler, true)
+
+		state := &TaskState{
+			ID:     "test-cancel",
+			Query:  "Test query",
+			Intent: &TaskIntent{Type: "reasoning"},
+			Status: StatusInProgress,
+		}
+
+		// Create cancelled context
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		result, err := orch.streamingFeedbackLoop(ctx, state, streamHandler)
+
+		assert.Error(t, err)
+		assert.Equal(t, StatusCancelled, state.Status)
+		assert.NotNil(t, result)
+	})
+}
+
+func TestFormatStreamingSummary(t *testing.T) {
+	orch := &Orchestrator{}
+
+	result := &TaskResult{
+		Duration: 5 * 1000000000, // 5 seconds
+		Status:   StatusCompleted,
+		History: []AgentResponse{
+			{AgentType: AgentReasoner},
+			{AgentType: AgentToolCaller},
+		},
+	}
+
+	summary := orch.formatStreamingSummary(result)
+
+	assert.Contains(t, summary, "Execution Summary")
+	assert.Contains(t, summary, "Duration: 5s")
+	assert.Contains(t, summary, "Agent interactions: 2")
+	assert.Contains(t, summary, "Status: completed")
+}
+
+// Helper function for string pointers
+func stringPtr(s string) *string {
+	return &s
+}

--- a/pkg/orchestrator/task_plan.go
+++ b/pkg/orchestrator/task_plan.go
@@ -1,0 +1,298 @@
+package orchestrator
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// TaskPlan represents a structured plan for complex task execution
+type TaskPlan struct {
+	ID           string                 `json:"id"`
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description"`
+	Tasks        []SubTask              `json:"tasks"`
+	Dependencies map[string][]string    `json:"dependencies"` // task_id -> [depends_on_ids]
+	CreatedAt    time.Time              `json:"created_at"`
+	UpdatedAt    time.Time              `json:"updated_at"`
+	Status       PlanStatus             `json:"status"`
+	Metadata     map[string]interface{} `json:"metadata"`
+}
+
+// SubTask represents an individual task within a plan
+type SubTask struct {
+	ID             string                 `json:"id"`
+	Name           string                 `json:"name"`
+	Description    string                 `json:"description"`
+	AgentType      AgentType              `json:"agent_type"`
+	Input          string                 `json:"input"`
+	ExpectedOutput string                 `json:"expected_output,omitempty"`
+	Status         TaskStatus             `json:"status"`
+	Result         string                 `json:"result,omitempty"`
+	Error          string                 `json:"error,omitempty"`
+	StartedAt      *time.Time             `json:"started_at,omitempty"`
+	CompletedAt    *time.Time             `json:"completed_at,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+	NextAction     *RouteDecision         `json:"next_action,omitempty"`
+}
+
+// PlanStatus represents the overall status of a task plan
+type PlanStatus string
+
+const (
+	PlanStatusDraft     PlanStatus = "draft"
+	PlanStatusReady     PlanStatus = "ready"
+	PlanStatusExecuting PlanStatus = "executing"
+	PlanStatusCompleted PlanStatus = "completed"
+	PlanStatusFailed    PlanStatus = "failed"
+	PlanStatusCancelled PlanStatus = "cancelled"
+)
+
+// TaskStatus represents the status of an individual task
+type TaskStatus string
+
+const (
+	TaskStatusPending   TaskStatus = "pending"
+	TaskStatusReady     TaskStatus = "ready"
+	TaskStatusRunning   TaskStatus = "running"
+	TaskStatusCompleted TaskStatus = "completed"
+	TaskStatusFailed    TaskStatus = "failed"
+	TaskStatusSkipped   TaskStatus = "skipped"
+)
+
+// generateID generates a random ID for tasks and plans
+func generateID() string {
+	b := make([]byte, 8)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// NewTaskPlan creates a new task plan
+func NewTaskPlan(name, description string) *TaskPlan {
+	return &TaskPlan{
+		ID:           generateID(),
+		Name:         name,
+		Description:  description,
+		Tasks:        []SubTask{},
+		Dependencies: make(map[string][]string),
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+		Status:       PlanStatusDraft,
+		Metadata:     make(map[string]interface{}),
+	}
+}
+
+// AddTask adds a subtask to the plan
+func (p *TaskPlan) AddTask(task SubTask) *TaskPlan {
+	if task.ID == "" {
+		task.ID = generateID()
+	}
+	if task.Status == "" {
+		task.Status = TaskStatusPending
+	}
+	if task.Metadata == nil {
+		task.Metadata = make(map[string]interface{})
+	}
+	p.Tasks = append(p.Tasks, task)
+	p.UpdatedAt = time.Now()
+	return p
+}
+
+// AddDependency adds a dependency between tasks
+func (p *TaskPlan) AddDependency(taskID string, dependsOnIDs ...string) *TaskPlan {
+	if p.Dependencies == nil {
+		p.Dependencies = make(map[string][]string)
+	}
+	p.Dependencies[taskID] = append(p.Dependencies[taskID], dependsOnIDs...)
+	p.UpdatedAt = time.Now()
+	return p
+}
+
+// GetTask retrieves a task by ID
+func (p *TaskPlan) GetTask(taskID string) (*SubTask, error) {
+	for i := range p.Tasks {
+		if p.Tasks[i].ID == taskID {
+			return &p.Tasks[i], nil
+		}
+	}
+	return nil, fmt.Errorf("task %s not found", taskID)
+}
+
+// UpdateTaskStatus updates the status of a specific task
+func (p *TaskPlan) UpdateTaskStatus(taskID string, status TaskStatus) error {
+	task, err := p.GetTask(taskID)
+	if err != nil {
+		return err
+	}
+
+	task.Status = status
+	now := time.Now()
+
+	switch status {
+	case TaskStatusRunning:
+		task.StartedAt = &now
+	case TaskStatusCompleted, TaskStatusFailed:
+		task.CompletedAt = &now
+	}
+
+	p.UpdatedAt = time.Now()
+	p.updatePlanStatus()
+	return nil
+}
+
+// UpdateTaskResult updates the result of a completed task
+func (p *TaskPlan) UpdateTaskResult(taskID string, result string, nextAction *RouteDecision) error {
+	task, err := p.GetTask(taskID)
+	if err != nil {
+		return err
+	}
+
+	task.Result = result
+	task.NextAction = nextAction
+	p.UpdatedAt = time.Now()
+	return nil
+}
+
+// GetReadyTasks returns tasks that are ready to execute (dependencies met)
+func (p *TaskPlan) GetReadyTasks() []SubTask {
+	ready := []SubTask{}
+
+	for _, task := range p.Tasks {
+		if task.Status != TaskStatusPending {
+			continue
+		}
+
+		// Check if all dependencies are completed
+		deps, hasDeps := p.Dependencies[task.ID]
+		if !hasDeps {
+			ready = append(ready, task)
+			continue
+		}
+
+		allDepsComplete := true
+		for _, depID := range deps {
+			depTask, err := p.GetTask(depID)
+			if err != nil || depTask.Status != TaskStatusCompleted {
+				allDepsComplete = false
+				break
+			}
+		}
+
+		if allDepsComplete {
+			ready = append(ready, task)
+		}
+	}
+
+	return ready
+}
+
+// GetNextTask returns the next task to execute based on dependencies
+func (p *TaskPlan) GetNextTask() (*SubTask, error) {
+	readyTasks := p.GetReadyTasks()
+	if len(readyTasks) == 0 {
+		return nil, fmt.Errorf("no tasks ready for execution")
+	}
+	return &readyTasks[0], nil
+}
+
+// IsComplete checks if all tasks in the plan are complete
+func (p *TaskPlan) IsComplete() bool {
+	for _, task := range p.Tasks {
+		if task.Status != TaskStatusCompleted && task.Status != TaskStatusSkipped {
+			return false
+		}
+	}
+	return true
+}
+
+// HasFailures checks if any task has failed
+func (p *TaskPlan) HasFailures() bool {
+	for _, task := range p.Tasks {
+		if task.Status == TaskStatusFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// updatePlanStatus updates the overall plan status based on task states
+func (p *TaskPlan) updatePlanStatus() {
+	if p.HasFailures() {
+		p.Status = PlanStatusFailed
+		return
+	}
+
+	if p.IsComplete() {
+		p.Status = PlanStatusCompleted
+		return
+	}
+
+	// Check if any task is running
+	for _, task := range p.Tasks {
+		if task.Status == TaskStatusRunning {
+			p.Status = PlanStatusExecuting
+			return
+		}
+	}
+
+	// If we have ready tasks, we're ready to execute
+	if len(p.GetReadyTasks()) > 0 {
+		p.Status = PlanStatusReady
+	}
+}
+
+// ToJSON serializes the plan to JSON
+func (p *TaskPlan) ToJSON() (string, error) {
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// FromJSON deserializes a plan from JSON
+func TaskPlanFromJSON(data string) (*TaskPlan, error) {
+	var plan TaskPlan
+	if err := json.Unmarshal([]byte(data), &plan); err != nil {
+		return nil, err
+	}
+	return &plan, nil
+}
+
+// BuildSequentialPlan creates a simple sequential plan from a list of tasks
+func BuildSequentialPlan(name string, tasks ...SubTask) *TaskPlan {
+	plan := NewTaskPlan(name, "Sequential execution plan")
+
+	var prevID string
+	for i, task := range tasks {
+		if task.ID == "" {
+			task.ID = fmt.Sprintf("task_%d", i+1)
+		}
+		plan.AddTask(task)
+
+		// Add dependency on previous task
+		if prevID != "" {
+			plan.AddDependency(task.ID, prevID)
+		}
+		prevID = task.ID
+	}
+
+	return plan
+}
+
+// BuildParallelPlan creates a plan where all tasks can run in parallel
+func BuildParallelPlan(name string, tasks ...SubTask) *TaskPlan {
+	plan := NewTaskPlan(name, "Parallel execution plan")
+
+	for i, task := range tasks {
+		if task.ID == "" {
+			task.ID = fmt.Sprintf("task_%d", i+1)
+		}
+		plan.AddTask(task)
+		// No dependencies, all can run in parallel
+	}
+
+	return plan
+}

--- a/pkg/tui/chat/key_msg.go
+++ b/pkg/tui/chat/key_msg.go
@@ -12,6 +12,25 @@ import (
 )
 
 func handleKeyMsg(m chatModel, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Check if the key should be handled by viewport for scrolling
+	switch msg.Type {
+	case tea.KeyUp, tea.KeyDown, tea.KeyPgUp, tea.KeyPgDown, tea.KeyHome, tea.KeyEnd:
+		// If textarea is not focused or is empty, let viewport handle scrolling
+		if !m.textarea.Focused() || m.textarea.Value() == "" {
+			var cmd tea.Cmd
+			m.viewport, cmd = m.viewport.Update(msg)
+			return m, cmd
+		}
+	case tea.KeyCtrlU:
+		// Ctrl+U for half page up
+		m.viewport.HalfPageUp()
+		return m, nil
+	case tea.KeyCtrlD:
+		// Ctrl+D for half page down
+		m.viewport.HalfPageDown()
+		return m, nil
+	}
+
 	switch msg.Type {
 	case tea.KeyEscape:
 		m.numEscPress++

--- a/pkg/tui/chat/model.go
+++ b/pkg/tui/chat/model.go
@@ -79,6 +79,8 @@ func NewChatModel(streamManager *tui.Manager, chatManager *chat.Manager, agent a
 	ta.FocusedStyle.Prompt = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.ColorGrey))
 
 	vp := viewport.New(80, 30)
+	vp.MouseWheelEnabled = true
+	vp.MouseWheelDelta = 3
 
 	ta.KeyMap.InsertNewline.SetEnabled(true)
 

--- a/pkg/tui/chat/update.go
+++ b/pkg/tui/chat/update.go
@@ -35,6 +35,12 @@ func (m chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// All key handling happens in handleKeyMsg
 		return handleKeyMsg(m, msg)
 
+	case tea.MouseMsg:
+		// Handle mouse scrolling for viewport
+		var cmd tea.Cmd
+		m.viewport, cmd = m.viewport.Update(msg)
+		return m, cmd
+
 	case errMsg:
 		m.err = msg
 		return m, nil


### PR DESCRIPTION
## Summary
- Made orchestrator the default and only execution mode for all queries
- Removed command-line flags for mode selection (--simple, --orchestrate)
- Added minimal visual feedback showing which agent is currently processing

## Changes

### Core Changes
- **Removed single-agent mode**: All queries now go through the orchestrator for proper routing
- **Simplified CLI**: Removed `--simple` and `--orchestrate` flags since orchestrator is now always active
- **Visual feedback**: Added `[agent_name]` markers when agents start processing
- **Real-time streaming**: Fixed streaming to show agent responses as they're generated

### UI Improvements
- **TUI scrolling**: Enabled viewport scrolling with keyboard (arrows, PgUp/PgDown, Ctrl+U/D) and mouse wheel
- **API updates**: Updated to non-deprecated viewport methods (HalfPageUp/HalfPageDown)

### Test Updates
- Updated test expectations to match new simplified output format
- Removed verbose routing messages from tests
- All tests passing with new orchestrator-only mode

## Test Plan
- [x] Run `task test` - all unit tests pass
- [x] Run `task check` - all linting and formatting checks pass
- [x] Test TUI mode scrolling with keyboard and mouse
- [x] Test headless mode shows agent markers
- [x] Verify streaming output works in both modes
- [x] Test various query types route to correct agents

## Breaking Changes
- The `--simple` flag has been removed
- The `--orchestrate` flag has been removed (orchestrator is now always active)

🤖 Generated with [Claude Code](https://claude.ai/code)