### PR TITLE
[TUI] Add view switcher with command palette modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
   - Simplified agent initialization from ~45 lines to 3 lines
   - Comprehensive unit tests with 96.1% code coverage
   - Support for dynamic tool loading and extension
+- **View Switcher with Command Palette** - Multi-view TUI navigation system
+  - Implemented command palette modal accessible via `Ctrl+P`
+  - Created flexible View interface for all TUI views
+  - Added view switcher using bubbles/list component with highlighted selection
+  - Centered modal overlay using lipgloss.Place() for proper positioning
+  - Three initial views: Chat, Settings (shows Ollama config), and History (recent messages)
+  - Navigation with j/k or arrow keys, Enter to select, Esc to cancel
+  - Modal automatically sizes to content with rounded border styling
+  - Proper state preservation when switching between views
 - **Orchestrator Testing Framework** - Comprehensive testing infrastructure for multi-agent orchestrator system
   - Mock LLM with configurable responses, intent analysis, and behavior simulation
   - Mock agents with tool calling simulation, failure rates, and retry logic

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -252,6 +254,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -12,7 +12,7 @@ import (
 	"github.com/killallgit/ryan/pkg/ollama"
 	"github.com/killallgit/ryan/pkg/stream"
 	"github.com/killallgit/ryan/pkg/stream/tui"
-	"github.com/killallgit/ryan/pkg/tui/chat"
+	"github.com/killallgit/ryan/pkg/tui/views"
 )
 
 func RunTUI(agent agent.Agent) error {
@@ -49,12 +49,14 @@ func RunTUIWithOptions(agent agent.Agent, continueHistory bool) error {
 		return err
 	}
 
-	// Create chat model with stream manager, chat manager, and injected agent
-	chatModel := chat.NewChatModel(manager, chatManager, agent)
+	// Create views
+	chatView := views.NewChatView(manager, chatManager, agent)
+	settingsView := views.NewSettingsView()
+	historyView := views.NewHistoryView(chatManager)
 
-	// Store the chat model for later reference
-	views := []tea.Model{chatModel}
-	root := NewRootModel(ctx, views...)
+	// Create view list
+	viewList := []views.View{chatView, settingsView, historyView}
+	root := NewRootModel(ctx, viewList)
 
 	// Create the program
 	p := tea.NewProgram(root, tea.WithContext(ctx), tea.WithAltScreen())

--- a/pkg/tui/root.go
+++ b/pkg/tui/root.go
@@ -5,14 +5,20 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/killallgit/ryan/pkg/tui/switcher"
+	"github.com/killallgit/ryan/pkg/tui/views"
 )
 
 type rootModel struct {
-	ctx        context.Context
-	activeView int
-	views      []tea.Model
-	width      int
-	height     int
+	ctx           context.Context
+	activeView    int
+	views         []views.View
+	width         int
+	height        int
+	showSwitcher  bool
+	switcherModel switcher.Model
+	previousView  int // Remember previous view when opening switcher
 }
 
 func (m rootModel) Init() tea.Cmd {
@@ -24,27 +30,77 @@ func (m rootModel) Init() tea.Cmd {
 }
 
 func (m rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var (
-		cmds []tea.Cmd
-	)
+	var cmds []tea.Cmd
 
+	// Handle window resize for all components
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+
+		// Update switcher dimensions
+		var cmd tea.Cmd
+		switcherModel, cmd := m.switcherModel.Update(msg)
+		m.switcherModel = switcherModel.(switcher.Model)
+		cmds = append(cmds, cmd)
+
+		// Pass to active view
+		if m.activeView < len(m.views) {
+			viewModel, cmd := m.views[m.activeView].Update(msg)
+			m.views[m.activeView] = viewModel.(views.View)
+			cmds = append(cmds, cmd)
+		}
+		return m, tea.Batch(cmds...)
+	}
+
+	// If switcher is showing, handle its input
+	if m.showSwitcher {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "esc", "ctrl+c":
+				// Close switcher without changing view
+				m.showSwitcher = false
+				return m, nil
+			case "enter":
+				// Switch to selected view
+				m.activeView = m.switcherModel.SelectedIndex()
+				m.showSwitcher = false
+				// Initialize the newly selected view
+				return m, m.views[m.activeView].Init()
+			}
+		}
+
+		// Pass all other messages to the switcher (including navigation)
+		var cmd tea.Cmd
+		switcherModel, cmd := m.switcherModel.Update(msg)
+		m.switcherModel = switcherModel.(switcher.Model)
+		return m, cmd
+	}
+
+	// Handle global keys
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, keys.Quit):
 			return m, tea.Quit
+		case msg.String() == "ctrl+p":
+			// Toggle switcher
+			m.showSwitcher = true
+			m.previousView = m.activeView
+			// Set the current view as selected in switcher
+			m.switcherModel.SetSelectedIndex(m.activeView)
+			return m, nil
 		case key.Matches(msg, keys.Help):
 			return m, nil
 		}
-
-	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
 	}
 
+	// Pass messages to active view when switcher is not showing
 	if m.activeView < len(m.views) {
 		var cmd tea.Cmd
-		m.views[m.activeView], cmd = m.views[m.activeView].Update(msg)
+		viewModel, cmd := m.views[m.activeView].Update(msg)
+		m.views[m.activeView] = viewModel.(views.View)
 		cmds = append(cmds, cmd)
 	}
 
@@ -52,13 +108,40 @@ func (m rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m rootModel) View() string {
-	return m.views[m.activeView].View()
+	baseView := m.views[m.activeView].View()
+
+	if m.showSwitcher {
+		// Get switcher content
+		switcherContent := m.switcherModel.View()
+
+		// Create a modal style with border and padding
+		modalStyle := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			Padding(1, 2).
+			BorderForeground(lipgloss.Color("240"))
+
+		// Render the modal with the switcher content
+		modal := modalStyle.Render(switcherContent)
+
+		// Center the modal over the base view using lipgloss.Place
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Center,
+			modal,
+			lipgloss.WithWhitespaceBackground(lipgloss.NoColor{}),
+		)
+	}
+
+	return baseView
 }
 
-func NewRootModel(ctx context.Context, views ...tea.Model) *rootModel {
+func NewRootModel(ctx context.Context, viewList []views.View) *rootModel {
 	return &rootModel{
-		ctx:        ctx,
-		activeView: 0,
-		views:      views,
+		ctx:           ctx,
+		activeView:    0,
+		views:         viewList,
+		switcherModel: switcher.New(viewList),
 	}
 }

--- a/pkg/tui/switcher/model.go
+++ b/pkg/tui/switcher/model.go
@@ -1,0 +1,130 @@
+package switcher
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/killallgit/ryan/pkg/tui/views"
+)
+
+// viewItem implements list.Item for views
+type viewItem struct {
+	view views.View
+}
+
+func (i viewItem) FilterValue() string { return i.view.Name() }
+func (i viewItem) Title() string       { return i.view.Name() }
+func (i viewItem) Description() string { return i.view.Description() }
+
+// Model represents the view switcher modal
+type Model struct {
+	list          list.Model
+	views         []views.View
+	selectedIndex int
+	width         int
+	height        int
+}
+
+// New creates a new switcher model
+func New(views []views.View) Model {
+	// Convert views to list items
+	items := make([]list.Item, len(views))
+	for i, v := range views {
+		items[i] = viewItem{view: v}
+	}
+
+	// Create delegate with minimal styling
+	delegate := list.NewDefaultDelegate()
+	delegate.ShowDescription = false
+	delegate.SetHeight(1)
+	delegate.SetSpacing(0)
+
+	// Style the selected item
+	delegate.Styles.SelectedTitle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("170")).
+		Background(lipgloss.Color("235"))
+
+	delegate.Styles.NormalTitle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("250"))
+
+	// Create list
+	l := list.New(items, delegate, 0, 0)
+	l.SetShowTitle(false)
+	l.SetShowStatusBar(false)
+	l.SetShowPagination(false)
+	l.SetShowHelp(false)
+	l.SetFilteringEnabled(false)
+
+	// Calculate size based on content
+	listHeight := len(views) // Just the items, no extra padding
+
+	// Find the longest name for width calculation
+	maxWidth := 0
+	for _, v := range views {
+		if len(v.Name()) > maxWidth {
+			maxWidth = len(v.Name())
+		}
+	}
+
+	// Add some padding for the list item styling
+	listWidth := maxWidth + 6
+	if listWidth < 20 {
+		listWidth = 20 // Minimum width
+	}
+
+	l.SetSize(listWidth, listHeight)
+
+	return Model{
+		list:  l,
+		views: views,
+	}
+}
+
+// Init initializes the switcher
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages for the switcher
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	}
+
+	// Let the list handle all updates including navigation
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	m.selectedIndex = m.list.Index()
+
+	return m, cmd
+}
+
+// View renders the switcher
+func (m Model) View() string {
+	return m.list.View()
+}
+
+// SelectedIndex returns the currently selected index
+func (m Model) SelectedIndex() int {
+	return m.list.Index()
+}
+
+// SetSelectedIndex sets the selected index
+func (m *Model) SetSelectedIndex(index int) {
+	if index >= 0 && index < len(m.views) {
+		m.list.Select(index)
+		m.selectedIndex = index
+	}
+}
+
+// Width returns the width of the list
+func (m Model) Width() int {
+	return m.list.Width()
+}
+
+// Height returns the height of the list
+func (m Model) Height() int {
+	return m.list.Height()
+}

--- a/pkg/tui/views/chat.go
+++ b/pkg/tui/views/chat.go
@@ -1,0 +1,48 @@
+package views
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/killallgit/ryan/pkg/agent"
+	chatpkg "github.com/killallgit/ryan/pkg/chat"
+	"github.com/killallgit/ryan/pkg/stream/tui"
+	"github.com/killallgit/ryan/pkg/tui/chat"
+)
+
+// ChatView wraps the existing chat model to implement the View interface
+type ChatView struct {
+	model tea.Model
+}
+
+// NewChatView creates a new chat view
+func NewChatView(streamManager *tui.Manager, chatManager *chatpkg.Manager, agent agent.Agent) ChatView {
+	return ChatView{
+		model: chat.NewChatModel(streamManager, chatManager, agent),
+	}
+}
+
+// Init initializes the chat view
+func (v ChatView) Init() tea.Cmd {
+	return v.model.Init()
+}
+
+// Update handles messages for the chat view
+func (v ChatView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	model, cmd := v.model.Update(msg)
+	v.model = model
+	return v, cmd
+}
+
+// View renders the chat view
+func (v ChatView) View() string {
+	return v.model.View()
+}
+
+// Name returns the display name for this view
+func (v ChatView) Name() string {
+	return "Chat"
+}
+
+// Description returns the description for this view
+func (v ChatView) Description() string {
+	return "Main chat interface"
+}

--- a/pkg/tui/views/history.go
+++ b/pkg/tui/views/history.go
@@ -1,0 +1,118 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/killallgit/ryan/pkg/chat"
+)
+
+// HistoryView displays chat history
+type HistoryView struct {
+	width       int
+	height      int
+	chatManager *chat.Manager
+	history     *chat.History
+	err         error
+}
+
+// NewHistoryView creates a new history view
+func NewHistoryView(chatManager *chat.Manager) HistoryView {
+	v := HistoryView{
+		chatManager: chatManager,
+	}
+	// Load history on creation
+	if chatManager != nil {
+		messages := chatManager.GetHistory()
+		v.history = &chat.History{Messages: messages}
+	}
+	return v
+}
+
+// Init initializes the history view
+func (v HistoryView) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages for the history view
+func (v HistoryView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "r":
+			// Refresh history
+			if v.chatManager != nil {
+				messages := v.chatManager.GetHistory()
+				v.history = &chat.History{Messages: messages}
+				v.err = nil
+			}
+		}
+	}
+	return v, nil
+}
+
+// View renders the history view
+func (v HistoryView) View() string {
+	var b strings.Builder
+
+	b.WriteString("=== Chat History ===\n\n")
+
+	if v.err != nil {
+		b.WriteString(fmt.Sprintf("Error loading history: %v\n", v.err))
+		return b.String()
+	}
+
+	if v.history == nil || len(v.history.Messages) == 0 {
+		b.WriteString("No chat history available.\n")
+	} else {
+		b.WriteString(fmt.Sprintf("Total messages: %d\n\n", len(v.history.Messages)))
+
+		// Show last 10 messages
+		start := len(v.history.Messages) - 10
+		if start < 0 {
+			start = 0
+		}
+
+		for i := start; i < len(v.history.Messages); i++ {
+			msg := v.history.Messages[i]
+			role := "Unknown"
+			switch msg.Role {
+			case chat.RoleUser:
+				role = "User"
+			case chat.RoleAssistant:
+				role = "Assistant"
+			case chat.RoleSystem:
+				role = "System"
+			}
+
+			// Truncate long messages
+			content := msg.Content
+			if len(content) > 80 {
+				content = content[:77] + "..."
+			}
+
+			b.WriteString(fmt.Sprintf("[%s] %s\n", role, content))
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString("Press 'r' to refresh\n")
+	b.WriteString("Press Ctrl+P to switch views\n")
+	b.WriteString("Press q to quit\n")
+
+	return b.String()
+}
+
+// Name returns the display name for this view
+func (v HistoryView) Name() string {
+	return "History"
+}
+
+// Description returns the description for this view
+func (v HistoryView) Description() string {
+	return "Browse chat history"
+}

--- a/pkg/tui/views/settings.go
+++ b/pkg/tui/views/settings.go
@@ -1,0 +1,79 @@
+package views
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// SettingsView displays application settings
+type SettingsView struct {
+	width  int
+	height int
+}
+
+// NewSettingsView creates a new settings view
+func NewSettingsView() SettingsView {
+	return SettingsView{}
+}
+
+// Init initializes the settings view
+func (v SettingsView) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages for the settings view
+func (v SettingsView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		v.height = msg.Height
+	}
+	return v, nil
+}
+
+// View renders the settings view
+func (v SettingsView) View() string {
+	var b strings.Builder
+
+	b.WriteString("=== Settings ===\n\n")
+
+	// Display Ollama configuration
+	ollamaHost := os.Getenv("OLLAMA_HOST")
+	if ollamaHost == "" {
+		ollamaHost = "Not configured"
+	}
+	b.WriteString(fmt.Sprintf("Ollama Host: %s\n", ollamaHost))
+
+	// Display default model
+	defaultModel := os.Getenv("OLLAMA_DEFAULT_MODEL")
+	if defaultModel == "" {
+		defaultModel = "Not configured"
+	}
+	b.WriteString(fmt.Sprintf("Default Model: %s\n", defaultModel))
+
+	// Display embedding model
+	embeddingModel := os.Getenv("OLLAMA_EMBEDDING_MODEL")
+	if embeddingModel == "" {
+		embeddingModel = "Not configured"
+	}
+	b.WriteString(fmt.Sprintf("Embedding Model: %s\n", embeddingModel))
+
+	b.WriteString("\n")
+	b.WriteString("Press Ctrl+P to switch views\n")
+	b.WriteString("Press q to quit\n")
+
+	return b.String()
+}
+
+// Name returns the display name for this view
+func (v SettingsView) Name() string {
+	return "Settings"
+}
+
+// Description returns the description for this view
+func (v SettingsView) Description() string {
+	return "Application configuration"
+}

--- a/pkg/tui/views/view.go
+++ b/pkg/tui/views/view.go
@@ -1,0 +1,10 @@
+package views
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// View represents a switchable view in the application
+type View interface {
+	tea.Model
+	Name() string        // Display name for the view
+	Description() string // Optional description
+}


### PR DESCRIPTION
## Summary
- Implemented a multi-view navigation system with command palette accessible via `Ctrl+P`
- Created flexible modal overlay using bubbles/list and lipgloss for proper rendering
- Added three initial views: Chat, Settings (Ollama config), and History (recent messages)

## Changes
- **View Interface**: Created standardized `View` interface for all TUI views
- **Switcher Modal**: Implemented modal with bubbles/list for proper selection highlighting
- **Lipgloss Integration**: Used lipgloss.Place() for centered modal positioning with flexible sizing
- **New Views**:
  - Settings view displays Ollama configuration (host, model settings)
  - History view shows recent chat messages with refresh capability
  - Chat view wrapped to implement View interface
- **Navigation**: j/k or arrow keys to navigate, Enter to select, Esc to cancel

## Test Plan
- [x] Build passes with `task build`
- [x] All tests pass with `task check`
- [x] Modal opens with Ctrl+P
- [x] Navigation works with j/k and arrow keys
- [x] All views are selectable including Settings
- [x] Esc properly closes modal without switching views
- [x] Modal properly flexes to content size
- [x] Long view names don't break border rendering

🤖 Generated with [Claude Code](https://claude.ai/code)